### PR TITLE
fix: stop cn() silently deleting utility classes

### DIFF
--- a/tests/classNames.test.js
+++ b/tests/classNames.test.js
@@ -83,6 +83,85 @@ describe('cn', () => {
         });
     });
 
+    describe('prefix families that share a stem but not a property', () => {
+        it('separates text-overflow from text colour', () => {
+            expect(cn('text-ellipsis text-slate-500')).toBe('text-ellipsis text-slate-500');
+            expect(cn('text-clip text-slate-500')).toBe('text-clip text-slate-500');
+        });
+
+        it('separates border-collapse from border colour', () => {
+            expect(cn('border-collapse border-slate-200'))
+                .toBe('border-collapse border-slate-200');
+            expect(cn('border-separate border-spacing-2 border-slate-200'))
+                .toBe('border-separate border-spacing-2 border-slate-200');
+        });
+
+        it('separates background position, clip, origin and blend from colour', () => {
+            expect(cn('bg-white bg-center bg-clip-padding'))
+                .toBe('bg-white bg-center bg-clip-padding');
+            expect(cn('bg-white bg-origin-border bg-blend-multiply'))
+                .toBe('bg-white bg-origin-border bg-blend-multiply');
+        });
+
+        it('separates object-fit from object-position', () => {
+            expect(cn('object-cover object-center')).toBe('object-cover object-center');
+        });
+
+        it('separates shadow size from shadow colour', () => {
+            expect(cn('shadow-lg shadow-indigo-500/50')).toBe('shadow-lg shadow-indigo-500/50');
+        });
+
+        it('separates the scale axes', () => {
+            expect(cn('scale-x-100 scale-y-50')).toBe('scale-x-100 scale-y-50');
+        });
+
+        it('separates divide reverse from divide width', () => {
+            expect(cn('divide-y-2 divide-y-reverse')).toBe('divide-y-2 divide-y-reverse');
+        });
+
+        it('separates ring opacity from ring colour', () => {
+            expect(cn('ring-indigo-500 ring-opacity-50')).toBe('ring-indigo-500 ring-opacity-50');
+        });
+
+        it('still merges within a single property', () => {
+            expect(cn('align-top align-middle')).toBe('align-middle');
+            expect(cn('object-cover object-contain')).toBe('object-contain');
+            expect(cn('shadow-sm shadow-lg')).toBe('shadow-lg');
+            expect(cn('bg-center bg-top')).toBe('bg-top');
+        });
+    });
+
+    describe('Bootstrap flexbox and breakpoint classes', () => {
+        it('treats flex-column as a direction, not a flex shorthand', () => {
+            expect(cn('d-flex flex-column flex-grow-1'))
+                .toBe('d-flex flex-column flex-grow-1');
+            expect(cn('flex-column-reverse flex-shrink-0 flex-fill'))
+                .toBe('flex-column-reverse flex-shrink-0 flex-fill');
+        });
+
+        it('merges opposing flex directions across both spellings', () => {
+            expect(cn('flex-row flex-column')).toBe('flex-column');
+            expect(cn('flex-grow-0 flex-grow-1')).toBe('flex-grow-1');
+        });
+
+        it('separates align-items, align-self and align-content', () => {
+            expect(cn('d-flex align-items-center align-self-end align-content-between'))
+                .toBe('d-flex align-items-center align-self-end align-content-between');
+        });
+
+        it('never merges across a responsive breakpoint infix', () => {
+            // Different media queries — collapsing them would drop a breakpoint.
+            expect(cn('m-3 m-md-5')).toBe('m-3 m-md-5');
+            expect(cn('flex-sm-row flex-md-column')).toBe('flex-sm-row flex-md-column');
+            expect(cn('d-none d-lg-block')).toBe('d-none d-lg-block');
+        });
+
+        it('does not mistake a trailing size suffix for a breakpoint infix', () => {
+            expect(cn('max-w-screen-sm max-w-screen-lg')).toBe('max-w-screen-lg');
+            expect(cn('btn btn-primary btn-sm')).toBe('btn btn-primary btn-sm');
+        });
+    });
+
     describe('variant prefixes', () => {
         it('scopes conflicts to a single variant', () => {
             expect(cn('bg-white hover:bg-slate-50')).toBe('bg-white hover:bg-slate-50');

--- a/tests/classNames.test.js
+++ b/tests/classNames.test.js
@@ -1,0 +1,209 @@
+/**
+ * Tests for class name merging (utils/classNames.js)
+ *
+ * `cn()` runs on every render of all 46 components, so a mis-grouped utility
+ * silently deletes styling framework-wide. The theme sweep at the bottom is
+ * the regression guard for that.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { cn, cls, twMerge, cond, variant, compose } from '../utils/classNames.js';
+import { tailwindTheme } from '../themes/tailwind/index.js';
+import { bootstrapTheme } from '../themes/bootstrap/index.js';
+
+describe('cn', () => {
+    describe('conflict resolution', () => {
+        it('keeps the last class when two set the same property', () => {
+            expect(cn('bg-blue-500', 'bg-red-500')).toBe('bg-red-500');
+        });
+
+        it('lets user classes override theme classes', () => {
+            expect(cn('bg-indigo-600 text-white', 'bg-red-500')).toBe('text-white bg-red-500');
+        });
+
+        it('lets size classes override base padding and font size', () => {
+            expect(cn('px-3 py-2 text-sm', 'px-2.5 py-1.5 text-xs')).toBe('px-2.5 py-1.5 text-xs');
+        });
+
+        it('keeps classes that set different properties', () => {
+            expect(cn('bg-blue-500', 'text-white', 'p-4')).toBe('bg-blue-500 text-white p-4');
+        });
+
+        it('collapses exact duplicates', () => {
+            expect(cn('btn', 'btn')).toBe('btn');
+        });
+
+        it('preserves the original order of surviving classes', () => {
+            expect(cn('inline-flex items-center gap-2 rounded-md'))
+                .toBe('inline-flex items-center gap-2 rounded-md');
+        });
+    });
+
+    describe('utility grouping', () => {
+        it('treats border width and border colour as different properties', () => {
+            expect(cn('bg-white border-b border-slate-200'))
+                .toBe('bg-white border-b border-slate-200');
+        });
+
+        it('treats each border side as its own property', () => {
+            expect(cn('border border-b-2 border-slate-200'))
+                .toBe('border border-b-2 border-slate-200');
+        });
+
+        it('does not confuse display with flex direction or wrapping', () => {
+            expect(cn('flex flex-wrap -mx-3')).toBe('flex flex-wrap -mx-3');
+            expect(cn('flex flex-col gap-0.5 p-3')).toBe('flex flex-col gap-0.5 p-3');
+        });
+
+        it('does not confuse display with grid templates', () => {
+            expect(cn('grid grid-cols-7 gap-0.5')).toBe('grid grid-cols-7 gap-0.5');
+        });
+
+        it('does not confuse text alignment with text colour or font size', () => {
+            expect(cn('text-left text-slate-600 text-xs')).toBe('text-left text-slate-600 text-xs');
+        });
+
+        it('keeps divide width alongside divide colour', () => {
+            expect(cn('divide-y divide-slate-100')).toBe('divide-y divide-slate-100');
+        });
+
+        it('keeps a full ring stack intact', () => {
+            expect(cn('ring-1 ring-inset ring-indigo-600/20'))
+                .toBe('ring-1 ring-inset ring-indigo-600/20');
+            expect(cn('ring-2 ring-offset-2 ring-indigo-500'))
+                .toBe('ring-2 ring-offset-2 ring-indigo-500');
+        });
+
+        it('treats corner radii as separate from the all-corner radius', () => {
+            expect(cn('rounded-lg rounded-t-none')).toBe('rounded-lg rounded-t-none');
+        });
+
+        it('keeps unrecognised classes verbatim', () => {
+            expect(cn('my-widget another-thing')).toBe('my-widget another-thing');
+        });
+    });
+
+    describe('variant prefixes', () => {
+        it('scopes conflicts to a single variant', () => {
+            expect(cn('bg-white hover:bg-slate-50')).toBe('bg-white hover:bg-slate-50');
+        });
+
+        it('resolves conflicts within the same variant', () => {
+            expect(cn('hover:bg-slate-50 hover:bg-red-50')).toBe('hover:bg-red-50');
+        });
+
+        it('keeps focus, hover and active states side by side', () => {
+            expect(cn('bg-indigo-600 hover:bg-indigo-700 active:bg-indigo-800'))
+                .toBe('bg-indigo-600 hover:bg-indigo-700 active:bg-indigo-800');
+        });
+
+        it('handles arbitrary variants containing colons', () => {
+            expect(cn('[&_tbody_tr:nth-child(odd)]:bg-slate-50/60 bg-white'))
+                .toBe('[&_tbody_tr:nth-child(odd)]:bg-slate-50/60 bg-white');
+        });
+
+        it('handles important markers', () => {
+            expect(cn('!bg-white bg-red-500')).toBe('bg-red-500');
+        });
+    });
+
+    describe('Bootstrap classes', () => {
+        it('resolves button colour variants', () => {
+            expect(cn('btn btn-primary', 'btn-danger')).toBe('btn btn-danger');
+        });
+
+        it('does not treat btn-group as a colour variant', () => {
+            expect(cn('btn-group btn-primary')).toBe('btn-group btn-primary');
+        });
+
+        it('keeps outline variants in the colour-variant group', () => {
+            expect(cn('btn btn-primary', 'btn-outline-secondary')).toBe('btn btn-outline-secondary');
+        });
+
+        it('keeps button size separate from button colour', () => {
+            expect(cn('btn btn-primary btn-sm')).toBe('btn btn-primary btn-sm');
+        });
+
+        it('keeps the long-form border sides', () => {
+            expect(cn('form-control border-end-0 border-secondary'))
+                .toBe('form-control border-end-0 border-secondary');
+        });
+    });
+
+    describe('argument handling', () => {
+        it('accepts objects with boolean conditions', () => {
+            expect(cn('a', { b: true, c: false }, ['d'])).toBe('a b d');
+        });
+
+        it('ignores null, undefined and non-strings', () => {
+            expect(cn('a', null, undefined, false, 0, 'b')).toBe('a b');
+        });
+
+        it('returns an empty string with no arguments', () => {
+            expect(cn()).toBe('');
+        });
+
+        it('splits multi-class strings', () => {
+            expect(cn('  a   b  ')).toBe('a b');
+        });
+    });
+
+    describe('aliases and helpers', () => {
+        it('cls behaves like cn', () => {
+            expect(cls('bg-blue-500', 'bg-red-500')).toBe('bg-red-500');
+        });
+
+        it('twMerge behaves like cn', () => {
+            expect(twMerge('px-4 py-2', 'px-6')).toBe('py-2 px-6');
+        });
+
+        it('cond applies classes conditionally', () => {
+            expect(cond('text-red-500', true)).toBe('text-red-500');
+            expect(cond('text-red-500', false)).toBe('');
+        });
+
+        it('variant resolves and falls back', () => {
+            const variants = { primary: 'bg-blue-500', default: 'bg-gray-500' };
+            expect(variant(variants, 'primary')).toBe('bg-blue-500');
+            expect(variant(variants, 'missing')).toBe('bg-gray-500');
+        });
+
+        it('compose merges the output of multiple functions', () => {
+            const composed = compose(() => 'btn', (v) => `btn-${v}`);
+            expect(composed('primary')).toBe('btn btn-primary');
+        });
+    });
+});
+
+describe('theme integrity under cn', () => {
+    /**
+     * Flatten every class string a theme declares.
+     * @param {Object} node - Theme fragment
+     * @param {string} path - Dotted path for failure messages
+     * @param {Array} out - Accumulator
+     */
+    function collect(node, path, out) {
+        Object.entries(node || {}).forEach(([key, value]) => {
+            if (typeof value === 'string') out.push([`${path}.${key}`, value]);
+            else if (value && typeof value === 'object') collect(value, `${path}.${key}`, out);
+        });
+    }
+
+    it.each([
+        ['tailwind', tailwindTheme],
+        ['bootstrap', bootstrapTheme]
+    ])('%s theme survives cn() with no class silently deleted', (_name, theme) => {
+        const strings = [];
+        collect(theme.components, '', strings);
+        expect(strings.length).toBeGreaterThan(0);
+
+        const losses = strings.flatMap(([path, value]) => {
+            const before = value.split(/\s+/).filter(Boolean);
+            const after = new Set(cn(value).split(/\s+/).filter(Boolean));
+            const dropped = before.filter(c => !after.has(c));
+            return dropped.length ? [`${path}: ${dropped.join(', ')}`] : [];
+        });
+
+        expect(losses).toEqual([]);
+    });
+});

--- a/utils/classNames.js
+++ b/utils/classNames.js
@@ -2,95 +2,326 @@
  * Smart class name utilities with conflict resolution
  *
  * Handles Tailwind-style class conflicts (e.g., bg-blue-500 vs bg-red-500)
- * Later classes override earlier classes for the same property.
+ * so that later classes override earlier ones for the same CSS property.
+ *
+ * Design rule: only drop a class when we are confident two classes set the
+ * same property. When a utility is not recognised it is kept verbatim —
+ * under-merging leaves a harmless duplicate, over-merging silently deletes
+ * styling (which is much harder to debug).
  *
  * @module utils/classNames
  */
 
+/* ---------------------------------------------------------------------------
+ * Utility vocabulary
+ * ------------------------------------------------------------------------ */
+
+// Display values that are unambiguous. `table`/`list-item` are deliberately
+// excluded: Bootstrap ships `.table` and `.list-item` as component classes.
+const DISPLAY = new Set([
+  'block', 'inline-block', 'inline', 'flex', 'inline-flex',
+  'grid', 'inline-grid', 'flow-root', 'contents', 'hidden'
+]);
+
+const POSITION = new Set(['static', 'fixed', 'absolute', 'relative', 'sticky']);
+const TEXT_ALIGN = new Set(['left', 'center', 'right', 'justify', 'start', 'end']);
+const TEXT_WRAP = new Set(['wrap', 'nowrap', 'balance', 'pretty']);
+const TEXT_TRANSFORM = new Set(['uppercase', 'lowercase', 'capitalize', 'normal-case']);
+const TEXT_DECORATION = new Set(['underline', 'overline', 'line-through', 'no-underline']);
+const FONT_SIZE = new Set([
+  'xs', 'sm', 'base', 'lg', 'xl',
+  '2xl', '3xl', '4xl', '5xl', '6xl', '7xl', '8xl', '9xl'
+]);
+const FONT_WEIGHT = new Set([
+  'thin', 'extralight', 'light', 'normal', 'medium',
+  'semibold', 'bold', 'extrabold', 'black'
+]);
+const FONT_FAMILY = new Set(['sans', 'serif', 'mono']);
+const LINE_STYLE = new Set(['solid', 'dashed', 'dotted', 'double', 'hidden', 'none']);
+
+// Tailwind logical/physical sides plus the Bootstrap long forms (border-bottom,
+// border-end-0, ...) so both frameworks group correctly.
+const SIDES = new Set([
+  'x', 'y', 't', 'r', 'b', 'l', 's', 'e',
+  'top', 'right', 'bottom', 'left', 'start', 'end'
+]);
+
+const BG_ATTACHMENT = new Set(['fixed', 'local', 'scroll']);
+const BG_SIZE = new Set(['auto', 'cover', 'contain']);
+const BG_REPEAT = new Set([
+  'repeat', 'no-repeat', 'repeat-x', 'repeat-y', 'repeat-round', 'repeat-space'
+]);
+
+const JUSTIFY_CONTENT = new Set([
+  'normal', 'start', 'end', 'center', 'between', 'around', 'evenly', 'stretch'
+]);
+
+// Bootstrap button colour variants (btn-group / btn-close are component classes,
+// not variants, so they must not be grouped together with these).
+const BS_BTN_VARIANTS = new Set([
+  'primary', 'secondary', 'success', 'danger', 'warning', 'info', 'light', 'dark', 'link'
+]);
+
+const isArbitrary = (v) =>
+  (v.startsWith('[') && v.endsWith(']')) || (v.startsWith('(') && v.endsWith(')'));
+
+const isNumeric = (v) => /^\d+(\.\d+)?$/.test(v) || v === 'px';
+
+// `text-[#fff]` is a colour; `text-[13px]` is a font size.
+const isArbitraryColor = (v) => /^\[(#|rgb|hsl|oklch|oklab|color[:(])/.test(v);
+
+const after = (value, prefix) => (value.startsWith(prefix) ? value.slice(prefix.length) : null);
+
+/* ---------------------------------------------------------------------------
+ * Variant handling
+ * ------------------------------------------------------------------------ */
+
 /**
- * Class groups for conflict detection
- * Each group represents a CSS property that can only have one value
+ * Split a class into its variant prefix and base utility.
+ *
+ * Bracket-aware, so arbitrary variants that contain colons stay intact:
+ * `[&_tr:nth-child(odd)]:bg-slate-50` produces prefix `[&_tr:nth-child(odd)]:`
+ * and base `bg-slate-50`.
+ *
+ * @param {string} cls - Full class name
+ * @returns {{prefix: string, base: string}}
+ * @private
  */
-const classGroups = {
-  // Tailwind class groups
-  bg: /^bg-(?!gradient)/,  // Background color (not gradient)
-  bgGradient: /^bg-gradient-/,
-  text: /^text-(?!xs|sm|base|lg|xl|2xl|3xl|4xl|5xl|6xl|7xl|8xl|9xl)/,  // text-color, not text-size
-  textSize: /^text-(xs|sm|base|lg|xl|2xl|3xl|4xl|5xl|6xl|7xl|8xl|9xl)/,
-  font: /^font-(thin|extralight|light|normal|medium|semibold|bold|extrabold|black)/,
-  fontFamily: /^font-(sans|serif|mono)/,
-  border: /^border-(?!\d|t-|r-|b-|l-|x-|y-|solid|dashed|dotted|double|none)/,  // border-color
-  borderWidth: /^border-(\d|t-\d|r-\d|b-\d|l-\d|x-\d|y-\d)/,
-  borderStyle: /^border-(solid|dashed|dotted|double|none)/,
-  rounded: /^rounded/,
-  shadow: /^shadow/,
-  opacity: /^opacity-/,
+function splitVariants(cls) {
+  let depth = 0;
+  let lastColon = -1;
 
-  // Spacing - Padding
-  p: /^p-/,
-  px: /^px-/,
-  py: /^py-/,
-  pt: /^pt-/,
-  pr: /^pr-/,
-  pb: /^pb-/,
-  pl: /^pl-/,
+  for (let i = 0; i < cls.length; i++) {
+    const ch = cls[i];
+    if (ch === '[' || ch === '(') depth++;
+    else if (ch === ']' || ch === ')') depth--;
+    else if (ch === ':' && depth === 0) lastColon = i;
+  }
 
-  // Spacing - Margin
-  m: /^m-/,
-  mx: /^mx-/,
-  my: /^my-/,
-  mt: /^mt-/,
-  mr: /^mr-/,
-  mb: /^mb-/,
-  ml: /^ml-/,
+  return lastColon === -1
+    ? { prefix: '', base: cls }
+    : { prefix: cls.slice(0, lastColon + 1), base: cls.slice(lastColon + 1) };
+}
 
-  // Sizing
-  w: /^w-/,
-  h: /^h-/,
-  minW: /^min-w-/,
-  minH: /^min-h-/,
-  maxW: /^max-w-/,
-  maxH: /^max-h-/,
+/* ---------------------------------------------------------------------------
+ * Group resolution
+ * ------------------------------------------------------------------------ */
 
-  // Display
-  display: /^(block|inline-block|inline|flex|inline-flex|grid|inline-grid|hidden)/,
+/**
+ * Resolve a base utility to a conflict group.
+ *
+ * Two classes conflict only when they share both a variant prefix and a group.
+ * Returning `null` means "unknown utility" — the class is always kept.
+ *
+ * @param {string} raw - Base utility, without variant prefix
+ * @returns {string|null} - Conflict group key, or null when unrecognised
+ * @private
+ */
+function getGroup(raw) {
+  // Strip Tailwind's important markers (`!p-0` / `p-0!`)
+  let base = raw;
+  if (base.startsWith('!')) base = base.slice(1);
+  if (base.endsWith('!')) base = base.slice(0, -1);
+  if (!base) return null;
 
-  // Position
-  position: /^(static|fixed|absolute|relative|sticky)/,
+  const negative = base.startsWith('-');
+  const bare = negative ? base.slice(1) : base;
 
-  // Z-index
-  z: /^z-/,
+  // --- standalone keywords -------------------------------------------------
+  if (DISPLAY.has(bare)) return 'display';
+  if (POSITION.has(bare)) return 'position';
+  if (TEXT_TRANSFORM.has(bare)) return 'text-transform';
+  if (TEXT_DECORATION.has(bare)) return 'text-decoration';
+  if (bare === 'italic' || bare === 'not-italic') return 'font-style';
+  if (bare === 'visible' || bare === 'invisible') return 'visibility';
+  if (bare === 'truncate') return 'text-overflow';
+  if (bare === 'border') return 'border-w';
+  if (bare === 'rounded') return 'rounded';
+  if (bare === 'shadow') return 'shadow';
+  if (bare === 'ring') return 'ring-w';
+  if (bare === 'outline') return 'outline-style';
 
-  // Bootstrap class groups
-  bgBs: /^bg-(primary|secondary|success|danger|warning|info|light|dark|white|transparent)/,
-  textBs: /^text-(primary|secondary|success|danger|warning|info|light|dark|white|muted|body)/,
-  btnBs: /^btn-(primary|secondary|success|danger|warning|info|light|dark|outline-primary|outline-secondary|outline-success|outline-danger|outline-warning|outline-info|outline-light|outline-dark)/,
-  sizeBs: /^(btn-sm|btn-lg|form-control-sm|form-control-lg)/,
+  // --- spacing (margin / padding, incl. negative values) -------------------
+  const spacing = bare.match(/^([mp])([trblxyse])?-(.+)$/);
+  if (spacing) return `space-${spacing[1]}${spacing[2] || ''}`;
 
-  // Flexbox/Grid
-  flexDirection: /^flex-(row|col)/,
-  flexWrap: /^flex-(wrap|nowrap)/,
-  justifyContent: /^justify-/,
-  alignItems: /^items-/,
-  alignSelf: /^self-/,
-  gridCols: /^grid-cols-/,
-  gridRows: /^grid-rows-/,
-  gap: /^gap-/,
-};
+  // --- sizing --------------------------------------------------------------
+  const sizing = bare.match(/^(min-w|min-h|max-w|max-h|size|w|h)-(.+)$/);
+  if (sizing) return `size-${sizing[1]}`;
+
+  // --- inset / offsets -----------------------------------------------------
+  const inset = bare.match(/^(inset-x|inset-y|inset|top|right|bottom|left|start|end)-(.+)$/);
+  if (inset) return `inset-${inset[1]}`;
+
+  // --- text-* --------------------------------------------------------------
+  let v = after(bare, 'text-');
+  if (v !== null) {
+    if (TEXT_ALIGN.has(v)) return 'text-align';
+    if (TEXT_WRAP.has(v)) return 'text-wrap';
+    if (v.startsWith('opacity-')) return 'text-opacity';
+    if (FONT_SIZE.has(v)) return 'font-size';
+    if (isArbitrary(v)) return isArbitraryColor(v) ? 'text-color' : 'font-size';
+    return 'text-color';
+  }
+
+  // --- font-* --------------------------------------------------------------
+  v = after(bare, 'font-');
+  if (v !== null) {
+    if (FONT_WEIGHT.has(v)) return 'font-weight';
+    if (FONT_FAMILY.has(v)) return 'font-family';
+    return isNumeric(v) || isArbitrary(v) ? 'font-weight' : 'font-family';
+  }
+
+  // --- border-* ------------------------------------------------------------
+  v = after(bare, 'border-');
+  if (v !== null) {
+    if (LINE_STYLE.has(v)) return 'border-style';
+    if (isNumeric(v) || isArbitrary(v)) return 'border-w';
+    if (v.startsWith('spacing-')) return 'border-spacing';
+    const side = v.match(/^([a-z]+)(?:-(.*))?$/);
+    if (side && SIDES.has(side[1])) {
+      const rest = side[2];
+      // `border-b`, `border-b-2`, `border-end-0` are widths for that side.
+      // `border-t-indigo-600` is a colour for that side.
+      if (rest === undefined || isNumeric(rest) || isArbitrary(rest)) {
+        return `border-w-${side[1]}`;
+      }
+      return `border-color-${side[1]}`;
+    }
+    return 'border-color';
+  }
+
+  // --- divide-* ------------------------------------------------------------
+  v = after(bare, 'divide-');
+  if (v !== null) {
+    const axis = v.match(/^([xy])(?:-|$)/);
+    if (axis) return `divide-w-${axis[1]}`;
+    if (LINE_STYLE.has(v)) return 'divide-style';
+    return 'divide-color';
+  }
+
+  // --- ring / outline ------------------------------------------------------
+  v = after(bare, 'ring-');
+  if (v !== null) {
+    if (v === 'inset') return 'ring-inset';
+    if (isNumeric(v) || isArbitrary(v)) return 'ring-w';
+    const offset = after(v, 'offset-');
+    if (offset !== null) {
+      return isNumeric(offset) || isArbitrary(offset) ? 'ring-offset-w' : 'ring-offset-color';
+    }
+    return 'ring-color';
+  }
+
+  v = after(bare, 'outline-');
+  if (v !== null) {
+    if (LINE_STYLE.has(v)) return 'outline-style';
+    if (isNumeric(v) || isArbitrary(v)) return 'outline-w';
+    if (v.startsWith('offset-')) return 'outline-offset';
+    return 'outline-color';
+  }
+
+  // --- background ----------------------------------------------------------
+  v = after(bare, 'bg-');
+  if (v !== null) {
+    if (BG_ATTACHMENT.has(v)) return 'bg-attachment';
+    if (BG_SIZE.has(v)) return 'bg-size';
+    if (BG_REPEAT.has(v)) return 'bg-repeat';
+    if (v === 'none' || v.startsWith('gradient-') || v.startsWith('linear-') ||
+        v.startsWith('radial-') || v.startsWith('conic-')) {
+      return 'bg-image';
+    }
+    return 'bg-color';
+  }
+
+  // --- rounded -------------------------------------------------------------
+  v = after(bare, 'rounded-');
+  if (v !== null) {
+    const corner = v.match(/^(tl|tr|br|bl|ss|se|es|ee|t|r|b|l|s|e)(?:-|$)/);
+    return corner ? `rounded-${corner[1]}` : 'rounded';
+  }
+
+  // --- flexbox / grid ------------------------------------------------------
+  if (/^flex-(row|row-reverse|col|col-reverse)$/.test(bare)) return 'flex-direction';
+  if (/^flex-(wrap|wrap-reverse|nowrap)$/.test(bare)) return 'flex-wrap';
+  if (bare.startsWith('flex-')) return 'flex';
+  if (/^grow(-.+)?$/.test(bare)) return 'grow';
+  if (/^shrink(-.+)?$/.test(bare)) return 'shrink';
+  if (bare.startsWith('basis-')) return 'basis';
+  if (bare.startsWith('order-')) return 'order';
+  if (bare.startsWith('grid-cols-')) return 'grid-cols';
+  if (bare.startsWith('grid-rows-')) return 'grid-rows';
+  if (bare.startsWith('col-span-')) return 'col-span';
+  if (bare.startsWith('row-span-')) return 'row-span';
+  if (bare.startsWith('justify-items-')) return 'justify-items';
+  if (bare.startsWith('justify-self-')) return 'justify-self';
+  v = after(bare, 'justify-');
+  if (v !== null) return JUSTIFY_CONTENT.has(v) ? 'justify-content' : null;
+  if (bare.startsWith('items-')) return 'align-items';
+  if (bare.startsWith('self-')) return 'align-self';
+  if (bare.startsWith('content-')) return 'align-content';
+  if (bare.startsWith('place-items-')) return 'place-items';
+  if (bare.startsWith('place-content-')) return 'place-content';
+  const gap = bare.match(/^gap(-[xy])?-(.+)$/);
+  if (gap) return `gap${gap[1] || ''}`;
+
+  // --- misc single-property utilities --------------------------------------
+  if (bare.startsWith('overflow-x-')) return 'overflow-x';
+  if (bare.startsWith('overflow-y-')) return 'overflow-y';
+  if (bare.startsWith('overflow-')) return 'overflow';
+  if (bare.startsWith('z-')) return 'z';
+  if (bare.startsWith('opacity-')) return 'opacity';
+  if (bare.startsWith('shadow-')) return 'shadow';
+  if (bare.startsWith('animate-')) return 'animate';
+  if (bare.startsWith('duration-')) return 'duration';
+  if (bare.startsWith('delay-')) return 'delay';
+  if (bare.startsWith('ease-')) return 'ease';
+  if (bare === 'transition' || bare.startsWith('transition-')) return 'transition';
+  if (bare.startsWith('tracking-')) return 'tracking';
+  if (bare.startsWith('leading-')) return 'leading';
+  if (bare.startsWith('whitespace-')) return 'whitespace';
+  if (bare.startsWith('cursor-')) return 'cursor';
+  if (bare.startsWith('select-')) return 'select';
+  if (bare.startsWith('pointer-events-')) return 'pointer-events';
+  if (bare.startsWith('appearance-')) return 'appearance';
+  if (bare.startsWith('accent-')) return 'accent';
+  if (bare.startsWith('object-')) return 'object';
+  if (bare.startsWith('align-')) return 'vertical-align';
+  if (bare.startsWith('rotate-')) return 'rotate';
+  if (bare.startsWith('scale-')) return 'scale';
+  if (bare.startsWith('translate-x-')) return 'translate-x';
+  if (bare.startsWith('translate-y-')) return 'translate-y';
+  if (bare.startsWith('fill-')) return 'fill';
+  if (bare.startsWith('stroke-')) return isNumeric(after(bare, 'stroke-')) ? 'stroke-w' : 'stroke';
+
+  // --- Bootstrap component variants ----------------------------------------
+  if (bare === 'btn-sm' || bare === 'btn-lg') return 'bs-btn-size';
+  v = after(bare, 'btn-');
+  if (v !== null) {
+    const outlined = after(v, 'outline-');
+    if (BS_BTN_VARIANTS.has(outlined !== null ? outlined : v)) return 'bs-btn-variant';
+    return null;
+  }
+  if (/^form-control-(sm|lg)$/.test(bare)) return 'bs-form-control-size';
+  if (/^form-select-(sm|lg)$/.test(bare)) return 'bs-form-select-size';
+  if (/^pagination-(sm|lg)$/.test(bare)) return 'bs-pagination-size';
+  if (/^modal-(sm|lg|xl)$/.test(bare)) return 'bs-modal-size';
+
+  return null;
+}
+
+/* ---------------------------------------------------------------------------
+ * Public API
+ * ------------------------------------------------------------------------ */
 
 /**
  * Merge class names with intelligent conflict resolution
  *
- * When multiple classes belong to the same group (e.g., both set background color),
- * only the last one is kept. Classes that don't conflict are all preserved.
+ * When multiple classes set the same CSS property under the same variant
+ * (e.g. both set a background colour), only the last one is kept. Everything
+ * else is preserved in its original order.
  *
  * @param {...string|Object|Array} classNames - Class name strings, objects, or arrays to merge
  * @returns {string} - Merged class string with conflicts resolved
- *
- * @example
- * // Simple merging
- * cn('btn', 'btn-primary', 'hover:btn-secondary')
- * // => "btn btn-primary hover:btn-secondary"
  *
  * @example
  * // Conflict resolution
@@ -98,9 +329,14 @@ const classGroups = {
  * // => "bg-red-500" (last one wins)
  *
  * @example
- * // No conflict (different properties)
- * cn('bg-blue-500', 'text-white', 'p-4')
- * // => "bg-blue-500 text-white p-4"
+ * // Width and colour are different properties — both survive
+ * cn('border-b border-slate-200')
+ * // => "border-b border-slate-200"
+ *
+ * @example
+ * // Variants are scoped independently
+ * cn('bg-white hover:bg-slate-50')
+ * // => "bg-white hover:bg-slate-50"
  *
  * @example
  * // Mixed arguments
@@ -108,47 +344,35 @@ const classGroups = {
  * // => "base-class conditional-class user-class"
  */
 export function cn(...classNames) {
-  const classMap = new Map();
-  const independentClasses = [];
+  const entries = [];
 
-  // Flatten and process all class names
-  const allClasses = flattenClassNames(classNames);
-
-  allClasses.forEach(className => {
+  flattenClassNames(classNames).forEach(className => {
     if (!className || typeof className !== 'string') return;
 
-    // Split on whitespace to handle space-separated classes
     className.split(/\s+/).forEach(cls => {
       if (!cls) return;
 
-      // Check if this class belongs to any conflict group
-      let groupKey = null;
+      const { prefix, base } = splitVariants(cls);
+      const group = getGroup(base);
 
-      for (const [group, pattern] of Object.entries(classGroups)) {
-        if (pattern.test(cls)) {
-          groupKey = group;
-          break;
-        }
-      }
-
-      if (groupKey) {
-        // This class belongs to a conflict group - it can override previous classes in same group
-        classMap.set(groupKey, cls);
-      } else {
-        // Independent class - doesn't conflict with anything
-        // Only add if not already present (avoid duplicates)
-        if (!independentClasses.includes(cls)) {
-          independentClasses.push(cls);
-        }
-      }
+      // Unknown utilities only collapse against an identical class, so nothing
+      // is ever deleted on a guess.
+      entries.push({ cls, key: group ? `${prefix} ${group}` : ` exact ${cls}` });
     });
   });
 
-  // Combine group classes and independent classes
-  const groupClasses = Array.from(classMap.values());
-  const result = [...groupClasses, ...independentClasses];
+  // Walk backwards keeping the last occurrence of each key, then restore order.
+  const seen = new Set();
+  const kept = [];
 
-  return result.join(' ');
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const { cls, key } = entries[i];
+    if (seen.has(key)) continue;
+    seen.add(key);
+    kept.push(cls);
+  }
+
+  return kept.reverse().join(' ');
 }
 
 /**
@@ -193,10 +417,6 @@ function flattenClassNames(args) {
  * cls('base', { active: isActive, disabled: isDisabled }, userClass)
  * // If isActive=true, isDisabled=false, userClass='custom'
  * // => "base active custom"
- *
- * @example
- * cls('btn', ['btn-primary', 'btn-lg'], { 'btn-disabled': disabled })
- * // => "btn btn-primary btn-lg" (if disabled=false)
  */
 export function cls(...args) {
   return cn(...args);
@@ -229,7 +449,6 @@ export function twMerge(...classNames) {
  * @example
  * cond('text-red-500', hasError)
  * // => "text-red-500" if hasError is true
- * // => "" if hasError is false
  */
 export function cond(classes, condition) {
   return condition ? classes : '';
@@ -244,13 +463,8 @@ export function cond(classes, condition) {
  * @returns {string} - Classes for selected variant
  *
  * @example
- * const variants = {
- *   primary: 'bg-blue-500 text-white',
- *   secondary: 'bg-gray-500 text-white',
- *   danger: 'bg-red-500 text-white'
- * };
- * variant(variants, 'primary')
- * // => "bg-blue-500 text-white"
+ * variant({ primary: 'bg-blue-500', danger: 'bg-red-500' }, 'primary')
+ * // => "bg-blue-500"
  */
 export function variant(variants, selectedVariant, defaultVariant = 'default') {
   return variants[selectedVariant] || variants[defaultVariant] || '';
@@ -263,10 +477,7 @@ export function variant(variants, selectedVariant, defaultVariant = 'default') {
  * @returns {Function} - Composed function
  *
  * @example
- * const baseClasses = () => 'btn';
- * const variantClasses = (variant) => `btn-${variant}`;
- * const composed = compose(baseClasses, variantClasses);
- * composed('primary')
+ * compose(() => 'btn', (v) => `btn-${v}`)('primary')
  * // => "btn btn-primary"
  */
 export function compose(...fns) {

--- a/utils/classNames.js
+++ b/utils/classNames.js
@@ -26,6 +26,12 @@ const DISPLAY = new Set([
 const POSITION = new Set(['static', 'fixed', 'absolute', 'relative', 'sticky']);
 const TEXT_ALIGN = new Set(['left', 'center', 'right', 'justify', 'start', 'end']);
 const TEXT_WRAP = new Set(['wrap', 'nowrap', 'balance', 'pretty']);
+const TEXT_OVERFLOW = new Set(['ellipsis', 'clip']);
+const VERTICAL_ALIGN = new Set([
+  'baseline', 'top', 'middle', 'bottom', 'text-top', 'text-bottom', 'sub', 'super'
+]);
+const OBJECT_FIT = new Set(['contain', 'cover', 'fill', 'none', 'scale-down']);
+const SHADOW_SIZE = new Set(['sm', 'md', 'lg', 'xl', '2xl', 'inner', 'none']);
 const TEXT_TRANSFORM = new Set(['uppercase', 'lowercase', 'capitalize', 'normal-case']);
 const TEXT_DECORATION = new Set(['underline', 'overline', 'line-through', 'no-underline']);
 const FONT_SIZE = new Set([
@@ -50,6 +56,10 @@ const BG_ATTACHMENT = new Set(['fixed', 'local', 'scroll']);
 const BG_SIZE = new Set(['auto', 'cover', 'contain']);
 const BG_REPEAT = new Set([
   'repeat', 'no-repeat', 'repeat-x', 'repeat-y', 'repeat-round', 'repeat-space'
+]);
+const BG_POSITION = new Set([
+  'bottom', 'center', 'left', 'right', 'top',
+  'left-bottom', 'left-top', 'right-bottom', 'right-top'
 ]);
 
 const JUSTIFY_CONTENT = new Set([
@@ -127,6 +137,13 @@ function getGroup(raw) {
   const negative = base.startsWith('-');
   const bare = negative ? base.slice(1) : base;
 
+  // Bootstrap encodes breakpoints as an infix (`flex-md-column`, `m-lg-3`)
+  // rather than a variant prefix. Two such classes target different media
+  // queries and must never collapse into each other, so leave them ungrouped.
+  if (!bare.includes('[') && /^[a-z]+(?:-[a-z]+)*?-(?:sm|md|lg|xl|xxl)-/.test(bare)) {
+    return null;
+  }
+
   // --- standalone keywords -------------------------------------------------
   if (DISPLAY.has(bare)) return 'display';
   if (POSITION.has(bare)) return 'position';
@@ -158,7 +175,9 @@ function getGroup(raw) {
   if (v !== null) {
     if (TEXT_ALIGN.has(v)) return 'text-align';
     if (TEXT_WRAP.has(v)) return 'text-wrap';
+    if (TEXT_OVERFLOW.has(v)) return 'text-overflow';
     if (v.startsWith('opacity-')) return 'text-opacity';
+    if (v.startsWith('shadow')) return 'text-shadow';
     if (FONT_SIZE.has(v)) return 'font-size';
     if (isArbitrary(v)) return isArbitraryColor(v) ? 'text-color' : 'font-size';
     return 'text-color';
@@ -176,6 +195,7 @@ function getGroup(raw) {
   v = after(bare, 'border-');
   if (v !== null) {
     if (LINE_STYLE.has(v)) return 'border-style';
+    if (v === 'collapse' || v === 'separate') return 'border-collapse';
     if (isNumeric(v) || isArbitrary(v)) return 'border-w';
     if (v.startsWith('spacing-')) return 'border-spacing';
     const side = v.match(/^([a-z]+)(?:-(.*))?$/);
@@ -195,7 +215,8 @@ function getGroup(raw) {
   v = after(bare, 'divide-');
   if (v !== null) {
     const axis = v.match(/^([xy])(?:-|$)/);
-    if (axis) return `divide-w-${axis[1]}`;
+    // `divide-y-reverse` flips the border side; it does not set a width.
+    if (axis) return v.endsWith('-reverse') ? `divide-reverse-${axis[1]}` : `divide-w-${axis[1]}`;
     if (LINE_STYLE.has(v)) return 'divide-style';
     return 'divide-color';
   }
@@ -204,6 +225,7 @@ function getGroup(raw) {
   v = after(bare, 'ring-');
   if (v !== null) {
     if (v === 'inset') return 'ring-inset';
+    if (v.startsWith('opacity-')) return 'ring-opacity';
     if (isNumeric(v) || isArbitrary(v)) return 'ring-w';
     const offset = after(v, 'offset-');
     if (offset !== null) {
@@ -226,6 +248,11 @@ function getGroup(raw) {
     if (BG_ATTACHMENT.has(v)) return 'bg-attachment';
     if (BG_SIZE.has(v)) return 'bg-size';
     if (BG_REPEAT.has(v)) return 'bg-repeat';
+    if (BG_POSITION.has(v)) return 'bg-position';
+    if (v.startsWith('clip-')) return 'bg-clip';
+    if (v.startsWith('origin-')) return 'bg-origin';
+    if (v.startsWith('blend-')) return 'bg-blend';
+    if (v.startsWith('opacity-')) return 'bg-opacity';
     if (v === 'none' || v.startsWith('gradient-') || v.startsWith('linear-') ||
         v.startsWith('radial-') || v.startsWith('conic-')) {
       return 'bg-image';
@@ -241,8 +268,14 @@ function getGroup(raw) {
   }
 
   // --- flexbox / grid ------------------------------------------------------
-  if (/^flex-(row|row-reverse|col|col-reverse)$/.test(bare)) return 'flex-direction';
+  // `col`/`col-reverse` are Tailwind; `column`/`column-reverse` are Bootstrap.
+  if (/^flex-(row|row-reverse|col|col-reverse|column|column-reverse)$/.test(bare)) {
+    return 'flex-direction';
+  }
   if (/^flex-(wrap|wrap-reverse|nowrap)$/.test(bare)) return 'flex-wrap';
+  // Bootstrap spells these `flex-grow-1` / `flex-shrink-0`.
+  if (/^flex-grow(-.+)?$/.test(bare)) return 'grow';
+  if (/^flex-shrink(-.+)?$/.test(bare)) return 'shrink';
   if (bare.startsWith('flex-')) return 'flex';
   if (/^grow(-.+)?$/.test(bare)) return 'grow';
   if (/^shrink(-.+)?$/.test(bare)) return 'shrink';
@@ -270,7 +303,10 @@ function getGroup(raw) {
   if (bare.startsWith('overflow-')) return 'overflow';
   if (bare.startsWith('z-')) return 'z';
   if (bare.startsWith('opacity-')) return 'opacity';
-  if (bare.startsWith('shadow-')) return 'shadow';
+  v = after(bare, 'shadow-');
+  if (v !== null) {
+    return SHADOW_SIZE.has(v) || isNumeric(v) || isArbitrary(v) ? 'shadow' : 'shadow-color';
+  }
   if (bare.startsWith('animate-')) return 'animate';
   if (bare.startsWith('duration-')) return 'duration';
   if (bare.startsWith('delay-')) return 'delay';
@@ -284,9 +320,18 @@ function getGroup(raw) {
   if (bare.startsWith('pointer-events-')) return 'pointer-events';
   if (bare.startsWith('appearance-')) return 'appearance';
   if (bare.startsWith('accent-')) return 'accent';
-  if (bare.startsWith('object-')) return 'object';
-  if (bare.startsWith('align-')) return 'vertical-align';
+  v = after(bare, 'object-');
+  if (v !== null) return OBJECT_FIT.has(v) ? 'object-fit' : 'object-position';
+  // Bootstrap's `align-items-*` / `align-self-*` / `align-content-*` are flexbox
+  // properties, not vertical-align — they share a prefix and nothing else.
+  if (bare.startsWith('align-items-')) return 'align-items';
+  if (bare.startsWith('align-self-')) return 'align-self';
+  if (bare.startsWith('align-content-')) return 'align-content';
+  v = after(bare, 'align-');
+  if (v !== null) return VERTICAL_ALIGN.has(v) ? 'vertical-align' : null;
   if (bare.startsWith('rotate-')) return 'rotate';
+  if (bare.startsWith('scale-x-')) return 'scale-x';
+  if (bare.startsWith('scale-y-')) return 'scale-y';
   if (bare.startsWith('scale-')) return 'scale';
   if (bare.startsWith('translate-x-')) return 'translate-x';
   if (bare.startsWith('translate-y-')) return 'translate-y';


### PR DESCRIPTION
## What does this PR do?

`cn()` grouped classes with unanchored regexes and kept only the last per group, so it deleted 17 classes across the Tailwind theme on every render — every `border-b`/`border-t`/`border-r` divider, both flex containers, both grids, three `text-left`s.

```
'flex flex-wrap -mx-3'      ->  'flex-wrap -mx-3'      Row is not a flex container
'border-b border-slate-200' ->  'border-slate-200'     no divider
'grid grid-cols-7 gap-0.5'  ->  'grid-cols-7 gap-0.5'  DatePicker is not a grid
```

Bootstrap lost zero classes through the same function, which is why this only ever showed under Tailwind.

Rewritten to resolve each class through its variant prefix and a precise utility group: border width, style and colour are distinct properties per side; display is distinct from flex-direction, flex-wrap and grid templates; conflicts are scoped per variant so `bg-white` and `hover:bg-slate-50` coexist; unrecognised utilities are never dropped. Overriding still works as documented — user classes and size classes beat base classes for the same property.

Second commit addresses review: fallback branches that returned a broad group before separating every property in that prefix family. `flex-column` vs `flex-grow-*`, `text-ellipsis` vs text colour, `border-collapse` vs border colour, `bg-*` position/clip/origin/blend vs colour, `align-items-*` vs `align-self-*`. A sweep of the remaining fallbacks found five more of the same shape (`object-fit` vs `object-position`, shadow size vs colour, `scale-x`/`scale-y`, `divide-y-reverse`, `ring-opacity`), plus Bootstrap's breakpoint infix — `m-3 m-md-5` was collapsing across media queries.

Refs #19.

## How was it tested?

- `npm test` — 696 passing, 50 in `tests/classNames.test.js`, including a sweep asserting neither shipped theme loses a class
- `npm run build` clean
- Verified in Chromium: `Row` renders `display: flex`, top bar and card dividers present

## Checklist

- [x] Tests pass (`npm test`)
- [x] New behavior is covered by tests
- [ ] CHANGELOG.md entry still to add
