### PR TITLE
test: remove uncaught async test exceptions

### DIFF
--- a/tests/unit/DataTable_Rendering.test.js
+++ b/tests/unit/DataTable_Rendering.test.js
@@ -33,7 +33,7 @@ describe('DataTable Rendering', () => {
         }
     });
 
-    it('should render table with columns and rows', (done) => {
+    it('should render table with columns and rows', async () => {
         const table = DataTable({
             columns: mockColumns,
             rows: mockRows,
@@ -42,7 +42,7 @@ describe('DataTable Rendering', () => {
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const tableElement = container.querySelector('table.datatable');
             expect(tableElement).not.toBeNull();
 
@@ -51,12 +51,9 @@ describe('DataTable Rendering', () => {
 
             const rows = container.querySelectorAll('tbody tr');
             expect(rows.length).toBe(mockRows.length);
-
-            done();
-        }, 50);
     });
 
-    it('should render correct column headers', (done) => {
+    it('should render correct column headers', async () => {
         const table = DataTable({
             columns: mockColumns,
             rows: mockRows
@@ -64,7 +61,7 @@ describe('DataTable Rendering', () => {
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const headers = container.querySelectorAll('thead th');
             const headerTexts = Array.from(headers).map(h => h.textContent.trim());
 
@@ -72,12 +69,9 @@ describe('DataTable Rendering', () => {
             expect(headerTexts).toContain('Name');
             expect(headerTexts).toContain('Email');
             expect(headerTexts).toContain('Role');
-
-            done();
-        }, 50);
     });
 
-    it('should render correct data in cells', (done) => {
+    it('should render correct data in cells', async () => {
         const table = DataTable({
             columns: mockColumns,
             rows: mockRows
@@ -85,7 +79,7 @@ describe('DataTable Rendering', () => {
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const cells = container.querySelectorAll('tbody td');
             const cellTexts = Array.from(cells).map(c => c.textContent.trim());
 
@@ -93,12 +87,9 @@ describe('DataTable Rendering', () => {
             expect(cellTexts).toContain('John Doe');
             expect(cellTexts).toContain('john@example.com');
             expect(cellTexts).toContain('Admin');
-
-            done();
-        }, 50);
     });
 
-    it('should display loading state', (done) => {
+    it('should display loading state', async () => {
         const table = DataTable({
             columns: mockColumns,
             rows: [],
@@ -107,18 +98,15 @@ describe('DataTable Rendering', () => {
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const spinner = container.querySelector('.spinner-border');
             expect(spinner).not.toBeNull();
 
             const loadingText = container.textContent;
             expect(loadingText).toContain('Loading');
-
-            done();
-        }, 50);
     });
 
-    it('should display error state', (done) => {
+    it('should display error state', async () => {
         const errorMessage = 'Failed to load data';
         const table = DataTable({
             columns: mockColumns,
@@ -128,18 +116,15 @@ describe('DataTable Rendering', () => {
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const errorDisplay = container.textContent;
             expect(errorDisplay).toContain(errorMessage);
 
             const warningIcon = container.querySelector('.bi-exclamation-triangle');
             expect(warningIcon).not.toBeNull();
-
-            done();
-        }, 50);
     });
 
-    it('should display empty message when no rows', (done) => {
+    it('should display empty message when no rows', async () => {
         const emptyMsg = 'No users found';
         const table = DataTable({
             columns: mockColumns,
@@ -149,15 +134,12 @@ describe('DataTable Rendering', () => {
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const message = container.textContent;
             expect(message).toContain(emptyMsg);
-
-            done();
-        }, 50);
     });
 
-    it('should render search filter when filterable', (done) => {
+    it('should render search filter when filterable', async () => {
         const table = DataTable({
             columns: mockColumns,
             rows: mockRows,
@@ -166,16 +148,13 @@ describe('DataTable Rendering', () => {
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const searchInput = container.querySelector('.datatable-search');
             expect(searchInput).not.toBeNull();
             expect(searchInput.placeholder).toContain('Search');
-
-            done();
-        }, 50);
     });
 
-    it('should not render search filter when not filterable', (done) => {
+    it('should not render search filter when not filterable', async () => {
         const table = DataTable({
             columns: mockColumns,
             rows: mockRows,
@@ -184,15 +163,12 @@ describe('DataTable Rendering', () => {
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const searchInput = container.querySelector('.datatable-search');
             expect(searchInput).toBeNull();
-
-            done();
-        }, 50);
     });
 
-    it('should render sort indicators on sortable columns', (done) => {
+    it('should render sort indicators on sortable columns', async () => {
         const table = DataTable({
             columns: mockColumns,
             rows: mockRows,
@@ -201,18 +177,15 @@ describe('DataTable Rendering', () => {
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const sortableHeaders = container.querySelectorAll('th.sortable');
             expect(sortableHeaders.length).toBeGreaterThan(0);
 
             const sortIcons = container.querySelectorAll('th.sortable i');
             expect(sortIcons.length).toBeGreaterThan(0);
-
-            done();
-        }, 50);
     });
 
-    it('should render checkboxes when selectable', (done) => {
+    it('should render checkboxes when selectable', async () => {
         const table = DataTable({
             columns: mockColumns,
             rows: mockRows,
@@ -221,18 +194,15 @@ describe('DataTable Rendering', () => {
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const selectAllCheckbox = container.querySelector('[data-ref="selectAll"]');
             expect(selectAllCheckbox).not.toBeNull();
 
             const rowCheckboxes = container.querySelectorAll('.datatable-row-checkbox');
             expect(rowCheckboxes.length).toBe(mockRows.length);
-
-            done();
-        }, 50);
     });
 
-    it('should not render checkboxes when not selectable', (done) => {
+    it('should not render checkboxes when not selectable', async () => {
         const table = DataTable({
             columns: mockColumns,
             rows: mockRows,
@@ -241,18 +211,15 @@ describe('DataTable Rendering', () => {
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const selectAllCheckbox = container.querySelector('[data-ref="selectAll"]');
             expect(selectAllCheckbox).toBeNull();
 
             const rowCheckboxes = container.querySelectorAll('.datatable-row-checkbox');
             expect(rowCheckboxes.length).toBe(0);
-
-            done();
-        }, 50);
     });
 
-    it('should render pagination when needed', (done) => {
+    it('should render pagination when needed', async () => {
         const table = DataTable({
             columns: mockColumns,
             rows: mockRows,
@@ -261,7 +228,7 @@ describe('DataTable Rendering', () => {
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const pagination = container.querySelector('nav[aria-label="Table pagination"]');
             expect(pagination).not.toBeNull();
 
@@ -269,12 +236,9 @@ describe('DataTable Rendering', () => {
             const nextBtn = container.querySelector('.datatable-next-page');
             expect(prevBtn).not.toBeNull();
             expect(nextBtn).not.toBeNull();
-
-            done();
-        }, 50);
     });
 
-    it('should hide pagination with single page', (done) => {
+    it('should hide pagination with single page', async () => {
         const table = DataTable({
             columns: mockColumns,
             rows: mockRows.slice(0, 5),
@@ -283,15 +247,12 @@ describe('DataTable Rendering', () => {
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const pagination = container.querySelector('nav[aria-label="Table pagination"]');
             expect(pagination).toBeNull();
-
-            done();
-        }, 50);
     });
 
-    it('should display row count in pagination', (done) => {
+    it('should display row count in pagination', async () => {
         const table = DataTable({
             columns: mockColumns,
             rows: mockRows,
@@ -300,17 +261,14 @@ describe('DataTable Rendering', () => {
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const paginationText = container.textContent;
             expect(paginationText).toContain('1');
             expect(paginationText).toContain('2');
             expect(paginationText).toContain('5'); // Total rows
-
-            done();
-        }, 50);
     });
 
-    it('should apply custom className', (done) => {
+    it('should apply custom className', async () => {
         const customClass = 'my-custom-table';
         const table = DataTable({
             columns: mockColumns,
@@ -320,15 +278,12 @@ describe('DataTable Rendering', () => {
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const wrapper = container.querySelector('.datatable-container');
             expect(wrapper.classList.contains(customClass)).toBe(true);
-
-            done();
-        }, 50);
     });
 
-    it('should escape HTML in data', (done) => {
+    it('should escape HTML in data', async () => {
         const maliciousData = [
             {
                 id: 1,
@@ -345,16 +300,13 @@ describe('DataTable Rendering', () => {
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const tableContent = container.textContent;
             expect(tableContent).toContain('<script>');
             expect(tableContent).not.toContain('alert("xss")');
 
             const scripts = container.querySelectorAll('script');
             expect(scripts.length).toBe(0);
-
-            done();
-        }, 50);
     });
 
     it('should handle empty columns array', () => {
@@ -374,22 +326,19 @@ describe('DataTable Rendering', () => {
         }).toThrow('columns must be a non-empty array');
     });
 
-    it('should handle undefined rows', (done) => {
+    it('should handle undefined rows', async () => {
         const table = DataTable({
             columns: mockColumns
         });
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const emptyMessage = container.textContent;
             expect(emptyMessage).toContain('No data available');
-
-            done();
-        }, 50);
     });
 
-    it('should render with default empty message', (done) => {
+    it('should render with default empty message', async () => {
         const table = DataTable({
             columns: mockColumns,
             rows: []
@@ -397,15 +346,12 @@ describe('DataTable Rendering', () => {
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const message = container.textContent;
             expect(message).toContain('No data available');
-
-            done();
-        }, 50);
     });
 
-    it('should render responsive wrapper', (done) => {
+    it('should render responsive wrapper', async () => {
         const table = DataTable({
             columns: mockColumns,
             rows: mockRows
@@ -413,15 +359,12 @@ describe('DataTable Rendering', () => {
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const responsive = container.querySelector('.table-responsive');
             expect(responsive).not.toBeNull();
-
-            done();
-        }, 50);
     });
 
-    it('should properly structure table HTML', (done) => {
+    it('should properly structure table HTML', async () => {
         const table = DataTable({
             columns: mockColumns,
             rows: mockRows
@@ -429,7 +372,7 @@ describe('DataTable Rendering', () => {
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const thead = container.querySelector('table > thead');
             const tbody = container.querySelector('table > tbody');
 
@@ -441,8 +384,5 @@ describe('DataTable Rendering', () => {
 
             expect(theadRows.length).toBe(1);
             expect(tbodyRows.length).toBe(mockRows.length);
-
-            done();
-        }, 50);
     });
 });

--- a/tests/unit/DataTable_Sorting.test.js
+++ b/tests/unit/DataTable_Sorting.test.js
@@ -32,7 +32,7 @@ describe('DataTable Sorting', () => {
         }
     });
 
-    it('should sort ascending on first click', (done) => {
+    it('should sort ascending on first click', async () => {
         const table = DataTable({
             columns: mockColumns,
             rows: mockRows,
@@ -41,21 +41,18 @@ describe('DataTable Sorting', () => {
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const nameHeader = container.querySelector('[data-column="name"]');
             nameHeader.click();
 
-            setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
                 const cells = container.querySelectorAll('tbody td[data-column="name"]');
                 const names = Array.from(cells).map(c => c.textContent.trim());
 
                 expect(names).toEqual(['Alice', 'Bob', 'Charlie']);
-                done();
-            }, 50);
-        }, 50);
     });
 
-    it('should sort descending on second click', (done) => {
+    it('should sort descending on second click', async () => {
         const table = DataTable({
             columns: mockColumns,
             rows: mockRows,
@@ -64,28 +61,24 @@ describe('DataTable Sorting', () => {
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const nameHeader = container.querySelector('[data-column="name"]');
 
             // First click - ascending
             nameHeader.click();
 
-            setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
                 // Second click - descending
                 nameHeader.click();
 
-                setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
                     const cells = container.querySelectorAll('tbody td[data-column="name"]');
                     const names = Array.from(cells).map(c => c.textContent.trim());
 
                     expect(names).toEqual(['Charlie', 'Bob', 'Alice']);
-                    done();
-                }, 50);
-            }, 50);
-        }, 50);
     });
 
-    it('should toggle sort direction', (done) => {
+    it('should toggle sort direction', async () => {
         const table = DataTable({
             columns: mockColumns,
             rows: mockRows
@@ -93,7 +86,7 @@ describe('DataTable Sorting', () => {
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const idHeader = container.querySelector('[data-column="id"]');
 
             // First sort: ascending
@@ -103,12 +96,9 @@ describe('DataTable Sorting', () => {
             // Second sort: descending
             idHeader.click();
             expect(table.getSortDirection()).toBe('desc');
-
-            done();
-        }, 50);
     });
 
-    it('should sort numeric columns correctly', (done) => {
+    it('should sort numeric columns correctly', async () => {
         const table = DataTable({
             columns: mockColumns,
             rows: mockRows
@@ -116,21 +106,18 @@ describe('DataTable Sorting', () => {
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const ageHeader = container.querySelector('[data-column="age"]');
             ageHeader.click();
 
-            setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
                 const cells = container.querySelectorAll('tbody td[data-column="age"]');
                 const ages = Array.from(cells).map(c => parseInt(c.textContent.trim()));
 
                 expect(ages).toEqual([28, 32, 35]);
-                done();
-            }, 50);
-        }, 50);
     });
 
-    it('should change sort column', (done) => {
+    it('should change sort column', async () => {
         const table = DataTable({
             columns: mockColumns,
             rows: mockRows
@@ -138,7 +125,7 @@ describe('DataTable Sorting', () => {
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const nameHeader = container.querySelector('[data-column="name"]');
             const ageHeader = container.querySelector('[data-column="age"]');
 
@@ -146,17 +133,13 @@ describe('DataTable Sorting', () => {
             nameHeader.click();
             expect(table.getSortColumn()).toBe('name');
 
-            setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
                 // Sort by age (changes sort column)
                 ageHeader.click();
                 expect(table.getSortColumn()).toBe('age');
-
-                done();
-            }, 50);
-        }, 50);
     });
 
-    it('should not sort non-sortable columns', (done) => {
+    it('should not sort non-sortable columns', async () => {
         const table = DataTable({
             columns: mockColumns,
             rows: mockRows
@@ -164,19 +147,16 @@ describe('DataTable Sorting', () => {
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const roleHeader = container.querySelector('[data-column="role"]');
             expect(roleHeader.classList.contains('sortable')).toBe(false);
 
             // Clicking should not trigger sort
             roleHeader.click();
             expect(table.getSortColumn()).toBeNull();
-
-            done();
-        }, 50);
     });
 
-    it('should call onSort callback', (done) => {
+    it('should call onSort callback', async () => {
         const onSort = vi.fn();
         const table = DataTable({
             columns: mockColumns,
@@ -186,24 +166,20 @@ describe('DataTable Sorting', () => {
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const nameHeader = container.querySelector('[data-column="name"]');
             nameHeader.click();
 
-            setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
                 expect(onSort).toHaveBeenCalledWith('name', 'asc');
 
                 nameHeader.click();
 
-                setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
                     expect(onSort).toHaveBeenCalledWith('name', 'desc');
-                    done();
-                }, 50);
-            }, 50);
-        }, 50);
     });
 
-    it('should display sort indicator on active column', (done) => {
+    it('should display sort indicator on active column', async () => {
         const table = DataTable({
             columns: mockColumns,
             rows: mockRows
@@ -211,22 +187,18 @@ describe('DataTable Sorting', () => {
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const nameHeader = container.querySelector('[data-column="name"]');
             nameHeader.click();
 
-            setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
                 expect(nameHeader.classList.contains('sorted-asc')).toBe(true);
 
                 const icon = nameHeader.querySelector('i');
                 expect(icon.classList.contains('bi-sort-up')).toBe(true);
-
-                done();
-            }, 50);
-        }, 50);
     });
 
-    it('should update sort indicator on descending', (done) => {
+    it('should update sort indicator on descending', async () => {
         const table = DataTable({
             columns: mockColumns,
             rows: mockRows
@@ -234,26 +206,21 @@ describe('DataTable Sorting', () => {
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const nameHeader = container.querySelector('[data-column="name"]');
             nameHeader.click();
 
-            setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
                 nameHeader.click(); // Second click
 
-                setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
                     expect(nameHeader.classList.contains('sorted-desc')).toBe(true);
 
                     const icon = nameHeader.querySelector('i');
                     expect(icon.classList.contains('bi-sort-down')).toBe(true);
-
-                    done();
-                }, 50);
-            }, 50);
-        }, 50);
     });
 
-    it('should reset page on sort', (done) => {
+    it('should reset page on sort', async () => {
         const manyRows = Array.from({ length: 25 }, (_, i) => ({
             id: i,
             name: ['Alice', 'Bob', 'Charlie'][i % 3],
@@ -270,28 +237,24 @@ describe('DataTable Sorting', () => {
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             // Go to page 2
             const nextBtn = container.querySelector('.datatable-next-page');
             nextBtn.click();
 
-            setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
                 expect(table.getCurrentPage()).toBe(2);
 
                 // Sort
                 const nameHeader = container.querySelector('[data-column="name"]');
                 nameHeader.click();
 
-                setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
                     // Should reset to page 1
                     expect(table.getCurrentPage()).toBe(1);
-                    done();
-                }, 50);
-            }, 50);
-        }, 50);
     });
 
-    it('should handle case-insensitive string sorting', (done) => {
+    it('should handle case-insensitive string sorting', async () => {
         const rows = [
             { id: 1, name: 'zebra', email: 'z@example.com', age: 20, role: 'User' },
             { id: 2, name: 'Apple', email: 'a@example.com', age: 25, role: 'User' },
@@ -305,24 +268,20 @@ describe('DataTable Sorting', () => {
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const nameHeader = container.querySelector('[data-column="name"]');
             nameHeader.click();
 
-            setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
                 const cells = container.querySelectorAll('tbody td[data-column="name"]');
                 const names = Array.from(cells).map(c => c.textContent.trim());
 
                 expect(names[0].toLowerCase()).toBe('apple');
                 expect(names[1].toLowerCase()).toBe('banana');
                 expect(names[2].toLowerCase()).toBe('zebra');
-
-                done();
-            }, 50);
-        }, 50);
     });
 
-    it('should track sort state via getSortColumn', (done) => {
+    it('should track sort state via getSortColumn', async () => {
         const table = DataTable({
             columns: mockColumns,
             rows: mockRows
@@ -330,20 +289,17 @@ describe('DataTable Sorting', () => {
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             expect(table.getSortColumn()).toBeNull();
 
             const idHeader = container.querySelector('[data-column="id"]');
             idHeader.click();
 
-            setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
                 expect(table.getSortColumn()).toBe('id');
-                done();
-            }, 50);
-        }, 50);
     });
 
-    it('should sort with null/undefined values', (done) => {
+    it('should sort with null/undefined values', async () => {
         const rows = [
             { id: 1, name: 'Alice', email: 'alice@example.com', age: 28, role: 'User' },
             { id: 2, name: null, email: 'bob@example.com', age: null, role: 'Admin' },
@@ -357,20 +313,17 @@ describe('DataTable Sorting', () => {
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const nameHeader = container.querySelector('[data-column="name"]');
             nameHeader.click();
 
-            setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
                 // Should not throw error
                 const cells = container.querySelectorAll('tbody tr');
                 expect(cells.length).toBe(3);
-                done();
-            }, 50);
-        }, 50);
     });
 
-    it('should handle sorting disabled', (done) => {
+    it('should handle sorting disabled', async () => {
         const table = DataTable({
             columns: mockColumns,
             rows: mockRows,
@@ -379,15 +332,12 @@ describe('DataTable Sorting', () => {
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const headers = container.querySelectorAll('th.sortable');
             expect(headers.length).toBe(0);
-
-            done();
-        }, 50);
     });
 
-    it('should update getSortDirection', (done) => {
+    it('should update getSortDirection', async () => {
         const table = DataTable({
             columns: mockColumns,
             rows: mockRows
@@ -395,18 +345,14 @@ describe('DataTable Sorting', () => {
 
         container.appendChild(table);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const nameHeader = container.querySelector('[data-column="name"]');
 
             nameHeader.click();
             expect(table.getSortDirection()).toBe('asc');
 
-            setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
                 nameHeader.click();
                 expect(table.getSortDirection()).toBe('desc');
-
-                done();
-            }, 50);
-        }, 50);
     });
 });

--- a/tests/unit/Dropdown_Interaction.test.js
+++ b/tests/unit/Dropdown_Interaction.test.js
@@ -19,22 +19,19 @@ describe('Dropdown Interaction', () => {
         }
     });
 
-    it('should render dropdown trigger button', (done) => {
+    it('should render dropdown trigger button', async () => {
         const dropdown = Dropdown({
             label: 'Actions'
         });
         container.appendChild(dropdown);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const trigger = container.querySelector('.dropdown-trigger');
             expect(trigger).not.toBeNull();
             expect(trigger.textContent).toContain('Actions');
-
-            done();
-        }, 50);
     });
 
-    it('should render menu items', (done) => {
+    it('should render menu items', async () => {
         const items = [
             { id: 'edit', label: 'Edit' },
             { id: 'delete', label: 'Delete' }
@@ -43,15 +40,12 @@ describe('Dropdown Interaction', () => {
         const dropdown = Dropdown({ items });
         container.appendChild(dropdown);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const menuItems = container.querySelectorAll('.dropdown-item');
             expect(menuItems.length).toBe(items.length);
-
-            done();
-        }, 50);
     });
 
-    it('should open dropdown on trigger click', (done) => {
+    it('should open dropdown on trigger click', async () => {
         const items = [
             { id: 'edit', label: 'Edit' }
         ];
@@ -59,21 +53,17 @@ describe('Dropdown Interaction', () => {
         const dropdown = Dropdown({ items });
         container.appendChild(dropdown);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const trigger = container.querySelector('.dropdown-trigger');
             trigger.click();
 
-            setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
                 expect(dropdown.isOpen()).toBe(true);
                 const menu = container.querySelector('.dropdown-menu');
                 expect(menu.style.display).toBe('block');
-
-                done();
-            }, 50);
-        }, 50);
     });
 
-    it('should close dropdown on second click', (done) => {
+    it('should close dropdown on second click', async () => {
         const items = [
             { id: 'edit', label: 'Edit' }
         ];
@@ -81,21 +71,17 @@ describe('Dropdown Interaction', () => {
         const dropdown = Dropdown({ items });
         container.appendChild(dropdown);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const trigger = container.querySelector('.dropdown-trigger');
             trigger.click();
 
-            setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
                 trigger.click();
 
                 expect(dropdown.isOpen()).toBe(false);
-
-                done();
-            }, 50);
-        }, 50);
     });
 
-    it('should call onSelect when item is clicked', (done) => {
+    it('should call onSelect when item is clicked', async () => {
         const onSelect = vi.fn();
         const items = [
             { id: 'edit', label: 'Edit' },
@@ -105,11 +91,11 @@ describe('Dropdown Interaction', () => {
         const dropdown = Dropdown({ items, onSelect });
         container.appendChild(dropdown);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const trigger = container.querySelector('.dropdown-trigger');
             trigger.click();
 
-            setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
                 const firstItem = container.querySelector('.dropdown-item-link');
                 firstItem.click();
 
@@ -119,13 +105,9 @@ describe('Dropdown Interaction', () => {
                     label: 'Edit',
                     index: 0
                 });
-
-                done();
-            }, 50);
-        }, 50);
     });
 
-    it('should close dropdown after selecting item', (done) => {
+    it('should close dropdown after selecting item', async () => {
         const items = [
             { id: 'edit', label: 'Edit' }
         ];
@@ -133,22 +115,18 @@ describe('Dropdown Interaction', () => {
         const dropdown = Dropdown({ items });
         container.appendChild(dropdown);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const trigger = container.querySelector('.dropdown-trigger');
             trigger.click();
 
-            setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
                 const item = container.querySelector('.dropdown-item-link');
                 item.click();
 
                 expect(dropdown.isOpen()).toBe(false);
-
-                done();
-            }, 50);
-        }, 50);
     });
 
-    it('should mark selected item as active', (done) => {
+    it('should mark selected item as active', async () => {
         const items = [
             { id: 'edit', label: 'Edit' },
             { id: 'delete', label: 'Delete' }
@@ -157,25 +135,20 @@ describe('Dropdown Interaction', () => {
         const dropdown = Dropdown({ items });
         container.appendChild(dropdown);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const trigger = container.querySelector('.dropdown-trigger');
             trigger.click();
 
-            setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
                 const secondItem = container.querySelectorAll('.dropdown-item')[1];
                 secondItem.querySelector('a').click();
 
-                setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
                     const activeItem = container.querySelector('.dropdown-item.active');
                     expect(activeItem).toBe(secondItem);
-
-                    done();
-                }, 50);
-            }, 50);
-        }, 50);
     });
 
-    it('should render items with icons', (done) => {
+    it('should render items with icons', async () => {
         const items = [
             { id: 'edit', label: 'Edit', icon: '✏️' },
             { id: 'delete', label: 'Delete', icon: '🗑️' }
@@ -184,16 +157,13 @@ describe('Dropdown Interaction', () => {
         const dropdown = Dropdown({ items });
         container.appendChild(dropdown);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const icons = container.querySelectorAll('.dropdown-item-icon');
             expect(icons.length).toBe(2);
             expect(icons[0].textContent).toContain('✏️');
-
-            done();
-        }, 50);
     });
 
-    it('should render items with badges', (done) => {
+    it('should render items with badges', async () => {
         const items = [
             { id: 'notifications', label: 'Notifications', badge: '5' },
             { id: 'messages', label: 'Messages', badge: '3' }
@@ -202,16 +172,13 @@ describe('Dropdown Interaction', () => {
         const dropdown = Dropdown({ items });
         container.appendChild(dropdown);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const badges = container.querySelectorAll('.dropdown-item-badge');
             expect(badges.length).toBe(2);
             expect(badges[0].textContent).toContain('5');
-
-            done();
-        }, 50);
     });
 
-    it('should render dividers between items', (done) => {
+    it('should render dividers between items', async () => {
         const items = [
             { id: 'edit', label: 'Edit' },
             { divider: true },
@@ -221,15 +188,12 @@ describe('Dropdown Interaction', () => {
         const dropdown = Dropdown({ items });
         container.appendChild(dropdown);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const divider = container.querySelector('.dropdown-divider');
             expect(divider).not.toBeNull();
-
-            done();
-        }, 50);
     });
 
-    it('should disable specific items', (done) => {
+    it('should disable specific items', async () => {
         const items = [
             { id: 'edit', label: 'Edit' },
             { id: 'delete', label: 'Delete', disabled: true }
@@ -238,15 +202,12 @@ describe('Dropdown Interaction', () => {
         const dropdown = Dropdown({ items });
         container.appendChild(dropdown);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const disabledItem = container.querySelectorAll('.dropdown-item')[1];
             expect(disabledItem.classList.contains('disabled')).toBe(true);
-
-            done();
-        }, 50);
     });
 
-    it('should not trigger callback for disabled items', (done) => {
+    it('should not trigger callback for disabled items', async () => {
         const onSelect = vi.fn();
         const items = [
             { id: 'edit', label: 'Edit', disabled: true }
@@ -255,28 +216,24 @@ describe('Dropdown Interaction', () => {
         const dropdown = Dropdown({ items, onSelect });
         container.appendChild(dropdown);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const trigger = container.querySelector('.dropdown-trigger');
             trigger.click();
 
-            setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
                 const disabledItem = container.querySelector('.dropdown-item-link');
                 if (disabledItem) {
                     disabledItem.click();
                 }
 
                 expect(onSelect).not.toHaveBeenCalled();
-
-                done();
-            }, 50);
-        }, 50);
     });
 
-    it('should support different positions', (done) => {
+    it('should support different positions', async () => {
         const positions = ['bottom-left', 'bottom-right', 'top-left', 'top-right'];
         let completed = 0;
 
-        positions.forEach((position) => {
+        for (const position of positions) {
             const div = document.createElement('div');
             container.appendChild(div);
 
@@ -286,19 +243,18 @@ describe('Dropdown Interaction', () => {
             });
             div.appendChild(dropdown);
 
-            setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
                 const menu = div.querySelector('.dropdown-menu');
                 expect(menu.classList.contains(`dropdown-${position}`)).toBe(true);
 
                 completed++;
                 if (completed === positions.length) {
-                    done();
                 }
-            }, 50);
-        });
+
+        }
     });
 
-    it('should handle keyboard navigation', (done) => {
+    it('should handle keyboard navigation', async () => {
         const items = [
             { id: 'item1', label: 'Item 1' },
             { id: 'item2', label: 'Item 2' }
@@ -307,7 +263,7 @@ describe('Dropdown Interaction', () => {
         const dropdown = Dropdown({ items });
         container.appendChild(dropdown);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const trigger = container.querySelector('.dropdown-trigger');
 
             const enterEvent = new KeyboardEvent('keydown', {
@@ -316,15 +272,11 @@ describe('Dropdown Interaction', () => {
             });
             trigger.dispatchEvent(enterEvent);
 
-            setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
                 expect(dropdown.isOpen()).toBe(true);
-
-                done();
-            }, 50);
-        }, 50);
     });
 
-    it('should close dropdown on outside click', (done) => {
+    it('should close dropdown on outside click', async () => {
         const items = [
             { id: 'edit', label: 'Edit' }
         ];
@@ -332,11 +284,11 @@ describe('Dropdown Interaction', () => {
         const dropdown = Dropdown({ items });
         container.appendChild(dropdown);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const trigger = container.querySelector('.dropdown-trigger');
             trigger.click();
 
-            setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
                 const outsideElement = document.createElement('div');
                 document.body.appendChild(outsideElement);
 
@@ -346,30 +298,23 @@ describe('Dropdown Interaction', () => {
                 });
                 outsideElement.dispatchEvent(clickEvent);
 
-                setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
                     expect(dropdown.isOpen()).toBe(false);
 
                     document.body.removeChild(outsideElement);
-                    done();
-                }, 50);
-            }, 50);
-        }, 50);
     });
 
-    it('should toggle dropdown programmatically', (done) => {
+    it('should toggle dropdown programmatically', async () => {
         const dropdown = Dropdown({
             items: [{ id: 'test', label: 'Test' }]
         });
         container.appendChild(dropdown);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             dropdown.toggle();
             expect(dropdown.isOpen()).toBe(true);
 
             dropdown.toggle();
             expect(dropdown.isOpen()).toBe(false);
-
-            done();
-        }, 50);
     });
 });

--- a/tests/unit/Sidebar_Navigation.test.js
+++ b/tests/unit/Sidebar_Navigation.test.js
@@ -19,7 +19,7 @@ describe('Sidebar Navigation', () => {
         }
     });
 
-    it('should render sidebar with menu items', (done) => {
+    it('should render sidebar with menu items', async () => {
         const items = [
             { id: 'home', label: 'Home', href: '#/' },
             { id: 'about', label: 'About', href: '#/about' }
@@ -28,18 +28,15 @@ describe('Sidebar Navigation', () => {
         const sidebar = Sidebar({ items });
         container.appendChild(sidebar);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const sidebarElement = container.querySelector('.sidebar');
             expect(sidebarElement).not.toBeNull();
 
             const menuItems = container.querySelectorAll('.sidebar-item');
             expect(menuItems.length).toBe(items.length);
-
-            done();
-        }, 50);
     });
 
-    it('should render with nested menu items', (done) => {
+    it('should render with nested menu items', async () => {
         const items = [
             {
                 id: 'settings',
@@ -54,7 +51,7 @@ describe('Sidebar Navigation', () => {
         const sidebar = Sidebar({ items });
         container.appendChild(sidebar);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const parentItem = container.querySelector('.sidebar-parent');
             expect(parentItem).not.toBeNull();
 
@@ -63,16 +60,13 @@ describe('Sidebar Navigation', () => {
 
             const subItems = container.querySelectorAll('.sidebar-subitem');
             expect(subItems.length).toBe(2);
-
-            done();
-        }, 50);
     });
 
-    it('should toggle sidebar open/closed', (done) => {
+    it('should toggle sidebar open/closed', async () => {
         const sidebar = Sidebar({ defaultOpen: true });
         container.appendChild(sidebar);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             expect(sidebar.isOpen()).toBe(true);
 
             sidebar.toggle();
@@ -80,12 +74,9 @@ describe('Sidebar Navigation', () => {
 
             sidebar.toggle();
             expect(sidebar.isOpen()).toBe(true);
-
-            done();
-        }, 50);
     });
 
-    it('should hide text when sidebar is collapsed', (done) => {
+    it('should hide text when sidebar is collapsed', async () => {
         const items = [
             { id: 'home', label: 'Home', href: '#/' }
         ];
@@ -96,22 +87,18 @@ describe('Sidebar Navigation', () => {
         });
         container.appendChild(sidebar);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const textElements = container.querySelectorAll('.sidebar-item-text');
             const initialDisplay = textElements[0]?.style.display;
 
             sidebar.toggle();
 
-            setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
                 const textElementsAfter = container.querySelectorAll('.sidebar-item-text');
                 expect(textElementsAfter[0]?.style.display).toBe('none');
-
-                done();
-            }, 50);
-        }, 50);
     });
 
-    it('should track active menu item', (done) => {
+    it('should track active menu item', async () => {
         const items = [
             { id: 'home', label: 'Home', href: '#/' },
             { id: 'about', label: 'About', href: '#/about' }
@@ -120,23 +107,19 @@ describe('Sidebar Navigation', () => {
         const sidebar = Sidebar({ items, activeItem: 'home' });
         container.appendChild(sidebar);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const activeItem = container.querySelector('.sidebar-item.active');
             expect(activeItem).not.toBeNull();
 
             sidebar.setActiveItem('about');
 
-            setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
                 const updatedActive = container.querySelector('.sidebar-item.active');
                 const aboutLink = updatedActive?.querySelector('[data-item-id="about"]');
                 expect(aboutLink).not.toBeNull();
-
-                done();
-            }, 50);
-        }, 50);
     });
 
-    it('should call onItemClick callback', (done) => {
+    it('should call onItemClick callback', async () => {
         const onItemClick = vi.fn();
         const items = [
             { id: 'home', label: 'Home', href: '#/' }
@@ -145,23 +128,19 @@ describe('Sidebar Navigation', () => {
         const sidebar = Sidebar({ items, onItemClick });
         container.appendChild(sidebar);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const itemBtn = container.querySelector('.sidebar-item-btn');
             itemBtn.click();
 
-            setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
                 expect(onItemClick).toHaveBeenCalled();
                 expect(onItemClick).toHaveBeenCalledWith({
                     id: 'home',
                     label: 'Home'
                 });
-
-                done();
-            }, 50);
-        }, 50);
     });
 
-    it('should expand/collapse submenu', (done) => {
+    it('should expand/collapse submenu', async () => {
         const items = [
             {
                 id: 'settings',
@@ -175,23 +154,19 @@ describe('Sidebar Navigation', () => {
         const sidebar = Sidebar({ items });
         container.appendChild(sidebar);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const submenu = container.querySelector('.sidebar-submenu');
             const initialDisplay = submenu.style.display;
 
             const toggleBtn = container.querySelector('.sidebar-parent-toggle button');
             toggleBtn.click();
 
-            setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
                 const submenuAfter = container.querySelector('.sidebar-submenu');
                 expect(submenuAfter.style.display).not.toBe(initialDisplay);
-
-                done();
-            }, 50);
-        }, 50);
     });
 
-    it('should render with dark mode', (done) => {
+    it('should render with dark mode', async () => {
         const items = [
             { id: 'home', label: 'Home', href: '#/' }
         ];
@@ -199,15 +174,12 @@ describe('Sidebar Navigation', () => {
         const sidebar = Sidebar({ items, darkMode: true });
         container.appendChild(sidebar);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const sidebarElement = container.querySelector('.sidebar');
             expect(sidebarElement.classList.contains('sidebar-dark')).toBe(true);
-
-            done();
-        }, 50);
     });
 
-    it('should render with custom width', (done) => {
+    it('should render with custom width', async () => {
         const customWidth = '300px';
         const items = [
             { id: 'home', label: 'Home', href: '#/' }
@@ -216,15 +188,12 @@ describe('Sidebar Navigation', () => {
         const sidebar = Sidebar({ items, width: customWidth });
         container.appendChild(sidebar);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const sidebarElement = container.querySelector('.sidebar');
             expect(sidebarElement.style.width).toBe(customWidth);
-
-            done();
-        }, 50);
     });
 
-    it('should render menu items with icons', (done) => {
+    it('should render menu items with icons', async () => {
         const items = [
             { id: 'home', label: 'Home', icon: '🏠', href: '#/' }
         ];
@@ -232,12 +201,9 @@ describe('Sidebar Navigation', () => {
         const sidebar = Sidebar({ items });
         container.appendChild(sidebar);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const icon = container.querySelector('.sidebar-icon');
             expect(icon).not.toBeNull();
             expect(icon.textContent).toContain('🏠');
-
-            done();
-        }, 50);
     });
 });

--- a/tests/unit/Stepper_Navigation.test.js
+++ b/tests/unit/Stepper_Navigation.test.js
@@ -19,7 +19,7 @@ describe('Stepper Navigation', () => {
         }
     });
 
-    it('should render stepper with steps', (done) => {
+    it('should render stepper with steps', async () => {
         const steps = [
             { title: 'Step 1', content: '<p>Step 1 content</p>' },
             { title: 'Step 2', content: '<p>Step 2 content</p>' }
@@ -28,15 +28,12 @@ describe('Stepper Navigation', () => {
         const stepper = Stepper({ steps });
         container.appendChild(stepper);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const stepElements = container.querySelectorAll('.stepper-step');
             expect(stepElements.length).toBe(steps.length);
-
-            done();
-        }, 50);
     });
 
-    it('should render in horizontal orientation by default', (done) => {
+    it('should render in horizontal orientation by default', async () => {
         const steps = [
             { title: 'Step 1', content: 'Content' },
             { title: 'Step 2', content: 'Content' }
@@ -45,15 +42,12 @@ describe('Stepper Navigation', () => {
         const stepper = Stepper({ steps, orientation: 'horizontal' });
         container.appendChild(stepper);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const stepperElement = container.querySelector('.stepper-horizontal');
             expect(stepperElement).not.toBeNull();
-
-            done();
-        }, 50);
     });
 
-    it('should render in vertical orientation', (done) => {
+    it('should render in vertical orientation', async () => {
         const steps = [
             { title: 'Step 1', content: 'Content' },
             { title: 'Step 2', content: 'Content' }
@@ -62,15 +56,12 @@ describe('Stepper Navigation', () => {
         const stepper = Stepper({ steps, orientation: 'vertical' });
         container.appendChild(stepper);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const stepperElement = container.querySelector('.stepper-vertical');
             expect(stepperElement).not.toBeNull();
-
-            done();
-        }, 50);
     });
 
-    it('should track current step', (done) => {
+    it('should track current step', async () => {
         const steps = [
             { title: 'Step 1', content: 'Content' },
             { title: 'Step 2', content: 'Content' }
@@ -79,14 +70,11 @@ describe('Stepper Navigation', () => {
         const stepper = Stepper({ steps, currentStep: 0 });
         container.appendChild(stepper);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             expect(stepper.getStep()).toBe(0);
-
-            done();
-        }, 50);
     });
 
-    it('should mark current step as active', (done) => {
+    it('should mark current step as active', async () => {
         const steps = [
             { title: 'Step 1', content: 'Content' },
             { title: 'Step 2', content: 'Content' }
@@ -95,16 +83,13 @@ describe('Stepper Navigation', () => {
         const stepper = Stepper({ steps, currentStep: 0 });
         container.appendChild(stepper);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const activeStep = container.querySelector('.stepper-step.active');
             expect(activeStep).not.toBeNull();
             expect(activeStep.querySelector('.stepper-step-title').textContent).toContain('Step 1');
-
-            done();
-        }, 50);
     });
 
-    it('should navigate to next step', (done) => {
+    it('should navigate to next step', async () => {
         const steps = [
             { title: 'Step 1', content: 'Content' },
             { title: 'Step 2', content: 'Content' },
@@ -114,16 +99,13 @@ describe('Stepper Navigation', () => {
         const stepper = Stepper({ steps, currentStep: 0 });
         container.appendChild(stepper);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             stepper.nextStep();
 
             expect(stepper.getStep()).toBe(1);
-
-            done();
-        }, 50);
     });
 
-    it('should navigate to previous step', (done) => {
+    it('should navigate to previous step', async () => {
         const steps = [
             { title: 'Step 1', content: 'Content' },
             { title: 'Step 2', content: 'Content' }
@@ -132,16 +114,13 @@ describe('Stepper Navigation', () => {
         const stepper = Stepper({ steps, currentStep: 1 });
         container.appendChild(stepper);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             stepper.prevStep();
 
             expect(stepper.getStep()).toBe(0);
-
-            done();
-        }, 50);
     });
 
-    it('should jump to specific step', (done) => {
+    it('should jump to specific step', async () => {
         const steps = [
             { title: 'Step 1', content: 'Content' },
             { title: 'Step 2', content: 'Content' },
@@ -151,16 +130,13 @@ describe('Stepper Navigation', () => {
         const stepper = Stepper({ steps, currentStep: 0 });
         container.appendChild(stepper);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             stepper.setStep(2);
 
             expect(stepper.getStep()).toBe(2);
-
-            done();
-        }, 50);
     });
 
-    it('should detect first step', (done) => {
+    it('should detect first step', async () => {
         const steps = [
             { title: 'Step 1', content: 'Content' },
             { title: 'Step 2', content: 'Content' }
@@ -169,20 +145,16 @@ describe('Stepper Navigation', () => {
         const stepper = Stepper({ steps, currentStep: 0 });
         container.appendChild(stepper);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             expect(stepper.isFirstStep()).toBe(true);
 
             stepper.nextStep();
 
-            setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
                 expect(stepper.isFirstStep()).toBe(false);
-
-                done();
-            }, 50);
-        }, 50);
     });
 
-    it('should detect last step', (done) => {
+    it('should detect last step', async () => {
         const steps = [
             { title: 'Step 1', content: 'Content' },
             { title: 'Step 2', content: 'Content' }
@@ -191,14 +163,11 @@ describe('Stepper Navigation', () => {
         const stepper = Stepper({ steps, currentStep: 1 });
         container.appendChild(stepper);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             expect(stepper.isLastStep()).toBe(true);
-
-            done();
-        }, 50);
     });
 
-    it('should mark completed steps', (done) => {
+    it('should mark completed steps', async () => {
         const steps = [
             { title: 'Step 1', content: 'Content' },
             { title: 'Step 2', content: 'Content' },
@@ -208,15 +177,12 @@ describe('Stepper Navigation', () => {
         const stepper = Stepper({ steps, currentStep: 2 });
         container.appendChild(stepper);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const completedSteps = container.querySelectorAll('.stepper-step.completed');
             expect(completedSteps.length).toBe(2);
-
-            done();
-        }, 50);
     });
 
-    it('should display checkmark for completed steps', (done) => {
+    it('should display checkmark for completed steps', async () => {
         const steps = [
             { title: 'Step 1', content: 'Content' },
             { title: 'Step 2', content: 'Content' }
@@ -225,15 +191,12 @@ describe('Stepper Navigation', () => {
         const stepper = Stepper({ steps, currentStep: 1 });
         container.appendChild(stepper);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const firstStepIndicator = container.querySelector('.stepper-step.completed .stepper-step-indicator');
             expect(firstStepIndicator.textContent).toContain('✓');
-
-            done();
-        }, 50);
     });
 
-    it('should call onStepChange callback', (done) => {
+    it('should call onStepChange callback', async () => {
         const onStepChange = vi.fn();
         const steps = [
             { title: 'Step 1', content: 'Content' },
@@ -243,7 +206,7 @@ describe('Stepper Navigation', () => {
         const stepper = Stepper({ steps, onStepChange });
         container.appendChild(stepper);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             stepper.setStep(1);
 
             expect(onStepChange).toHaveBeenCalled();
@@ -252,12 +215,9 @@ describe('Stepper Navigation', () => {
                 title: 'Step 2',
                 isCompleted: expect.any(Boolean)
             });
-
-            done();
-        }, 50);
     });
 
-    it('should return total steps count', (done) => {
+    it('should return total steps count', async () => {
         const steps = [
             { title: 'Step 1', content: 'Content' },
             { title: 'Step 2', content: 'Content' },
@@ -267,14 +227,11 @@ describe('Stepper Navigation', () => {
         const stepper = Stepper({ steps });
         container.appendChild(stepper);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             expect(stepper.getTotalSteps()).toBe(3);
-
-            done();
-        }, 50);
     });
 
-    it('should not navigate beyond step bounds', (done) => {
+    it('should not navigate beyond step bounds', async () => {
         const steps = [
             { title: 'Step 1', content: 'Content' },
             { title: 'Step 2', content: 'Content' }
@@ -283,19 +240,16 @@ describe('Stepper Navigation', () => {
         const stepper = Stepper({ steps, currentStep: 1 });
         container.appendChild(stepper);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             stepper.nextStep();
             expect(stepper.getStep()).toBe(1);
 
             stepper.setStep(0);
             stepper.prevStep();
             expect(stepper.getStep()).toBe(0);
-
-            done();
-        }, 50);
     });
 
-    it('should allow clicking previous steps when editable', (done) => {
+    it('should allow clicking previous steps when editable', async () => {
         const steps = [
             { title: 'Step 1', content: 'Content' },
             { title: 'Step 2', content: 'Content' }
@@ -304,15 +258,11 @@ describe('Stepper Navigation', () => {
         const stepper = Stepper({ steps, currentStep: 1, editable: true });
         container.appendChild(stepper);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const firstStep = container.querySelector('.stepper-step');
             firstStep.click();
 
-            setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
                 expect(stepper.getStep()).toBe(0);
-
-                done();
-            }, 50);
-        }, 50);
     });
 });

--- a/tests/unit/Tooltip_Positioning.test.js
+++ b/tests/unit/Tooltip_Positioning.test.js
@@ -24,21 +24,18 @@ describe('Tooltip Positioning', () => {
         }
     });
 
-    it('should render tooltip element', (done) => {
+    it('should render tooltip element', async () => {
         const tooltip = Tooltip({
             element: targetElement,
             content: 'Test tooltip'
         });
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const tooltipElement = document.querySelector('.tooltip');
             expect(tooltipElement).not.toBeNull();
-
-            done();
-        }, 50);
     });
 
-    it('should position tooltip on top by default', (done) => {
+    it('should position tooltip on top by default', async () => {
         const tooltip = Tooltip({
             element: targetElement,
             content: 'Test tooltip',
@@ -47,16 +44,13 @@ describe('Tooltip Positioning', () => {
 
         tooltip.show();
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const tooltipElement = document.querySelector('.tooltip');
             expect(tooltipElement).not.toBeNull();
             expect(tooltipElement.classList.contains('top')).toBe(true);
-
-            done();
-        }, 50);
     });
 
-    it('should position tooltip on bottom', (done) => {
+    it('should position tooltip on bottom', async () => {
         const tooltip = Tooltip({
             element: targetElement,
             content: 'Test tooltip',
@@ -65,15 +59,12 @@ describe('Tooltip Positioning', () => {
 
         tooltip.show();
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const tooltipElement = document.querySelector('.tooltip');
             expect(tooltipElement.classList.contains('bottom')).toBe(true);
-
-            done();
-        }, 50);
     });
 
-    it('should position tooltip on left', (done) => {
+    it('should position tooltip on left', async () => {
         const tooltip = Tooltip({
             element: targetElement,
             content: 'Test tooltip',
@@ -82,15 +73,12 @@ describe('Tooltip Positioning', () => {
 
         tooltip.show();
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const tooltipElement = document.querySelector('.tooltip');
             expect(tooltipElement.classList.contains('left')).toBe(true);
-
-            done();
-        }, 50);
     });
 
-    it('should position tooltip on right', (done) => {
+    it('should position tooltip on right', async () => {
         const tooltip = Tooltip({
             element: targetElement,
             content: 'Test tooltip',
@@ -99,15 +87,12 @@ describe('Tooltip Positioning', () => {
 
         tooltip.show();
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const tooltipElement = document.querySelector('.tooltip');
             expect(tooltipElement.classList.contains('right')).toBe(true);
-
-            done();
-        }, 50);
     });
 
-    it('should show tooltip on mouse enter', (done) => {
+    it('should show tooltip on mouse enter', async () => {
         const tooltip = Tooltip({
             element: targetElement,
             content: 'Test tooltip',
@@ -117,16 +102,13 @@ describe('Tooltip Positioning', () => {
         const mouseEnterEvent = new MouseEvent('mouseenter', { bubbles: true });
         targetElement.dispatchEvent(mouseEnterEvent);
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const tooltipElement = document.querySelector('.tooltip');
             expect(tooltipElement).not.toBeNull();
             expect(tooltipElement.classList.contains('visible')).toBe(true);
-
-            done();
-        }, 50);
     });
 
-    it('should hide tooltip on mouse leave', (done) => {
+    it('should hide tooltip on mouse leave', async () => {
         const tooltip = Tooltip({
             element: targetElement,
             content: 'Test tooltip',
@@ -135,20 +117,16 @@ describe('Tooltip Positioning', () => {
 
         tooltip.show();
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const mouseLeaveEvent = new MouseEvent('mouseleave', { bubbles: true });
             targetElement.dispatchEvent(mouseLeaveEvent);
 
-            setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
                 const tooltipElement = document.querySelector('.tooltip');
                 expect(tooltipElement.classList.contains('visible')).toBe(false);
-
-                done();
-            }, 50);
-        }, 50);
     });
 
-    it('should respect delay setting', (done) => {
+    it('should respect delay setting', async () => {
         const delay = 100;
         const tooltip = Tooltip({
             element: targetElement,
@@ -161,21 +139,17 @@ describe('Tooltip Positioning', () => {
         targetElement.dispatchEvent(mouseEnterEvent);
 
         // Tooltip should not be visible immediately
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 10));
             let tooltipElement = document.querySelector('.tooltip');
             expect(tooltipElement === null || !tooltipElement.classList.contains('visible')).toBe(true);
 
             // Wait for delay
-            setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, delay + 50));
                 tooltipElement = document.querySelector('.tooltip');
                 expect(tooltipElement).not.toBeNull();
-
-                done();
-            }, delay + 50);
-        }, 10);
     });
 
-    it('should update content dynamically', (done) => {
+    it('should update content dynamically', async () => {
         const tooltip = Tooltip({
             element: targetElement,
             content: 'Initial content'
@@ -183,17 +157,14 @@ describe('Tooltip Positioning', () => {
 
         tooltip.show();
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             tooltip.setContent('Updated content');
 
             const tooltipElement = document.querySelector('.tooltip');
             expect(tooltipElement.textContent).toContain('Updated content');
-
-            done();
-        }, 50);
     });
 
-    it('should display arrow when enabled', (done) => {
+    it('should display arrow when enabled', async () => {
         const tooltip = Tooltip({
             element: targetElement,
             content: 'Test tooltip',
@@ -202,15 +173,12 @@ describe('Tooltip Positioning', () => {
 
         tooltip.show();
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const arrow = document.querySelector('.tooltip-arrow');
             expect(arrow).not.toBeNull();
-
-            done();
-        }, 50);
     });
 
-    it('should not display arrow when disabled', (done) => {
+    it('should not display arrow when disabled', async () => {
         const tooltip = Tooltip({
             element: targetElement,
             content: 'Test tooltip',
@@ -219,15 +187,12 @@ describe('Tooltip Positioning', () => {
 
         tooltip.show();
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             const arrow = document.querySelector('.tooltip-arrow');
             expect(arrow).toBeNull();
-
-            done();
-        }, 50);
     });
 
-    it('should destroy tooltip and remove from DOM', (done) => {
+    it('should destroy tooltip and remove from DOM', async () => {
         const tooltip = Tooltip({
             element: targetElement,
             content: 'Test tooltip'
@@ -235,13 +200,10 @@ describe('Tooltip Positioning', () => {
 
         tooltip.show();
 
-        setTimeout(() => {
+        await new Promise(resolve => setTimeout(resolve, 50));
             tooltip.destroy();
 
             const tooltipElement = document.querySelector('.tooltip');
             expect(tooltipElement).toBeNull();
-
-            done();
-        }, 50);
     });
 });


### PR DESCRIPTION
Closes BaryoDev/rnxjs#18. Converts the six listed unit-test files from Vitest's removed done callback style to awaited delays, so assertions stay inside the test lifecycle and timer errors are not reported as uncaught exceptions. Test-only change; production behavior is unchanged. Verification: node --check passed for all six modified test files; git diff --check passed. npm test and focused Vitest could not complete because npm registry dependency installation hung in this environment. Build was not run because dependencies could not be installed.