### PR TITLE
test: query DataTable sort indicators after rerender

### DIFF
--- a/tests/unit/DataTable_Sorting.test.js
+++ b/tests/unit/DataTable_Sorting.test.js
@@ -192,9 +192,10 @@ describe('DataTable Sorting', () => {
             nameHeader.click();
 
         await new Promise(resolve => setTimeout(resolve, 50));
-                expect(nameHeader.classList.contains('sorted-asc')).toBe(true);
+                const sortedHeader = container.querySelector('[data-column="name"]');
+                expect(sortedHeader.classList.contains('sorted-asc')).toBe(true);
 
-                const icon = nameHeader.querySelector('i');
+                const icon = sortedHeader.querySelector('i');
                 expect(icon.classList.contains('bi-sort-up')).toBe(true);
     });
 
@@ -214,9 +215,10 @@ describe('DataTable Sorting', () => {
                 nameHeader.click(); // Second click
 
         await new Promise(resolve => setTimeout(resolve, 50));
-                    expect(nameHeader.classList.contains('sorted-desc')).toBe(true);
+                    const sortedHeader = container.querySelector('[data-column="name"]');
+                    expect(sortedHeader.classList.contains('sorted-desc')).toBe(true);
 
-                    const icon = nameHeader.querySelector('i');
+                    const icon = sortedHeader.querySelector('i');
                     expect(icon.classList.contains('bi-sort-down')).toBe(true);
     });
 


### PR DESCRIPTION
Closes BaryoDev/rnxjs#23. Sorting re-renders the table headers, so the two indicator tests were asserting against detached th elements captured before the click. Re-query the name header after each sort before checking its class and icon. Verification: the two sort-indicator tests passed with Vitest; git diff --check passed.