### PR TITLE
ci: run the suite on pull requests and before publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,36 +1,44 @@
-name: Publish to npm
+name: CI
 
 on:
-  release:
-    types: [created]
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  publish:
+  verify:
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20, 22]
+
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ matrix.node }}
           cache: npm
-          registry-url: https://registry.npmjs.org/
 
+      # `ci` over `install` so a lockfile that has drifted from package.json
+      # fails here rather than silently resolving something different.
       - run: npm ci
 
-      # The suite has to pass before anything reaches npm. Until this existed
-      # the publish path ran install, build, publish, and nothing else.
       - name: Test
         run: npm test
 
       - name: Build
         run: npm run build
 
+      # After the build, so this checks what the build actually emitted rather
+      # than what the source would have exported.
       - name: Entry points resolve
         run: |
           node -e "const m=require('./index.js'); if(!Object.keys(m).length) throw new Error('index.js exported nothing')"
           node --input-type=module -e "import('./dist/rnx.esm.js').then(m=>{if(!Object.keys(m).length) throw new Error('dist/rnx.esm.js exported nothing')})"
-
-      - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Closes #2.

## What was wrong

There was no workflow running the test suite. Not on pull requests, not on push, and not before publishing.

`npm-publish.yml` ran:

```
npm install  ->  npm run build  ->  npm publish
```

No test step anywhere in it. The suite has never gated a release. It also had a separate `build` job that `publish-npm` declared `needs: build` on, but that job's only step was `npm install`, so it read like a gate while proving nothing more than that npm could resolve the tree.

`dist/` is gitignored, so what reaches npm is whatever that unguarded build emits.

## What this adds

**`ci.yml`**, on pull requests and pushes to main, Node 20 and 22:

- `npm ci` rather than `npm install`, so a lockfile that has drifted from `package.json` fails here instead of silently resolving something else
- `npm test`
- `npm run build`
- an entry-point check that requires `index.js` and imports `dist/rnx.esm.js` and fails if either exports nothing

**`npm-publish.yml`** rewritten to run the same sequence before `npm publish`, and the no-op `build` job removed.

The entry-point check runs after the build on purpose, so it checks what the build emitted rather than what the source would have exported.

## This PR will go red, and that is correct

Six tests currently fail (#23, #24, #25). They were failing before too, as uncaught exceptions outside the test lifecycle, which is why the suite reported green while they were broken. Now that they run inside the lifecycle, CI reports them honestly.

Excluding them to get a green tick would recreate exactly the problem this PR exists to fix: a check that cannot fail. The right order is to land this, watch it go red, and fix the six.

## Verified locally

- `npm ci --dry-run` resolves clean, lockfile is in sync
- `npm run build` succeeds, emits both bundles
- both entry-point checks pass against the built output (77 exports each)
- `npm test` is 690 passed, 6 failed, 696 total
