### PR TITLE
fix: put dropdown-item on the anchor only

### DIFF
--- a/components/Dropdown/Dropdown.js
+++ b/components/Dropdown/Dropdown.js
@@ -53,6 +53,7 @@ export const Dropdown = (props = {}) => {
     const listClass = resolvePartClasses('dropdown', 'list') || 'dropdown-list';
     const dividerClass = cn(resolvePartClasses('dropdown', 'divider'), 'dropdown-divider');
     const linkClass = cn(resolvePartClasses('dropdown', 'item'), 'dropdown-item-link');
+    const itemWrapperClass = resolvePartClasses('dropdown', 'itemWrapper') || 'dropdown-item-wrapper';
     const itemIconClass = resolvePartClasses('dropdown', 'itemIcon') || 'dropdown-item-icon';
     const itemTextClass = resolvePartClasses('dropdown', 'itemText') || 'dropdown-item-text';
     const badgeClass = resolvePartClasses('dropdown', 'badge') || 'dropdown-item-badge';
@@ -63,8 +64,8 @@ export const Dropdown = (props = {}) => {
         }
 
         return `
-            <li class="${cn('dropdown-item', item.disabled ? 'disabled' : '', item.active ? 'active' : '')}" role="none" data-index="${index}">
-                <a href="${escapeHtml(item.href || '#')}" class="${linkClass}" role="menuitem" tabindex="-1"${item.disabled ? ' aria-disabled="true"' : ''} data-item-id="${escapeHtml(item.id || '')}">
+            <li class="${cn(itemWrapperClass, item.disabled ? 'disabled' : '', item.active ? 'active' : '')}" role="none" data-index="${index}">
+                <a href="${escapeHtml(item.href || '#')}" class="${cn(linkClass, item.disabled ? 'disabled' : '', item.active ? 'active' : '')}" role="menuitem" tabindex="-1"${item.disabled ? ' aria-disabled="true"' : ''} data-item-id="${escapeHtml(item.id || '')}">
                     ${item.icon ? `<span class="${itemIconClass}" aria-hidden="true">${escapeHtml(item.icon)}</span>` : ''}
                     <span class="${itemTextClass}">${escapeHtml(item.label)}</span>
                     ${item.badge ? `<span class="${badgeClass}">${escapeHtml(item.badge)}</span>` : ''}
@@ -117,7 +118,7 @@ export const Dropdown = (props = {}) => {
         }
 
         // Handle item clicks
-        const itemElements = el.querySelectorAll('.dropdown-item:not(.disabled)');
+        const itemElements = el.querySelectorAll('.dropdown-item-wrapper:not(.disabled)');
         itemElements.forEach(item => {
             const link = item.querySelector('.dropdown-item-link');
             if (link) {
@@ -129,10 +130,12 @@ export const Dropdown = (props = {}) => {
                     const itemIndex = parseInt(item.getAttribute('data-index'));
 
                     // Update active state
-                    el.querySelectorAll('.dropdown-item.active').forEach(activeEl => {
+                    el.querySelectorAll('.dropdown-item-wrapper.active').forEach(activeEl => {
                         activeEl.classList.remove('active');
+                        activeEl.querySelector('.dropdown-item-link')?.classList.remove('active');
                     });
                     item.classList.add('active');
+                    link.classList.add('active');
 
                     if (onSelect) {
                         onSelect({
@@ -168,7 +171,7 @@ export const Dropdown = (props = {}) => {
                 if (e.key === 'ArrowDown') {
                     e.preventDefault();
                     open();
-                    const firstItem = el.querySelector('.dropdown-item:not(.disabled) .dropdown-item-link');
+                    const firstItem = el.querySelector('.dropdown-item-wrapper:not(.disabled) .dropdown-item-link');
                     if (firstItem) {
                         firstItem.focus();
                     }
@@ -182,7 +185,7 @@ export const Dropdown = (props = {}) => {
         }
 
         // Keyboard navigation in menu
-        const menuItems = el.querySelectorAll('.dropdown-item:not(.disabled) .dropdown-item-link');
+        const menuItems = el.querySelectorAll('.dropdown-item-wrapper:not(.disabled) .dropdown-item-link');
         menuItems.forEach((item, index) => {
             const keydownHandler = (e) => {
                 if (e.key === 'ArrowDown') {

--- a/tests/unit/Dropdown_Interaction.test.js
+++ b/tests/unit/Dropdown_Interaction.test.js
@@ -140,8 +140,9 @@ describe('Dropdown Interaction', () => {
             trigger.click();
 
         await new Promise(resolve => setTimeout(resolve, 50));
+                // .dropdown-item is the anchor itself, matching Bootstrap's markup
                 const secondItem = container.querySelectorAll('.dropdown-item')[1];
-                secondItem.querySelector('a').click();
+                secondItem.click();
 
         await new Promise(resolve => setTimeout(resolve, 50));
                     const activeItem = container.querySelector('.dropdown-item.active');


### PR DESCRIPTION
Closes #25. Takes the suite to 696 of 696 passing.

## The problem

`dropdown-item` arrived on two elements from two independent places:

- `Dropdown.js:66` put the literal on the `<li>`
- `Dropdown.js:55` built the link class from `resolvePartClasses('dropdown', 'item')`, which the Bootstrap theme maps to `dropdown-item`

So two menu items matched four elements, and every internal query double-counted.

## Why the obvious fix was wrong

The tempting fix is to stop the anchor using the theme part and leave `dropdown-item` on the `<li>`. That breaks rendering.

`.dropdown-item` sets `display: block`, full-width padding, `color`, and `text-decoration: none`. That last one only means anything on an anchor, which is the tell: Bootstrap designed this class for the `<a>`, and canonical Bootstrap markup is `<li><a class="dropdown-item">` with no class on the `<li>` at all.

Leaving the class on the `<li>` would have made every entry render as a default underlined link and shrunk the click target from the full row to the text. All three tests would still have passed.

## What this does instead

The `<li>` takes a new `itemWrapper` part, following the existing `itemIcon` / `itemText` pattern, and the anchor keeps `dropdown-item` where Bootstrap expects it.

`active` and `disabled` now go on the anchor as well as the wrapper. Bootstrap styles `.dropdown-item.active` and `.dropdown-item.disabled`, which require both classes on the same element, so without this the states would have silently stopped rendering.

Rendered output, three items with one disabled and one active:

```html
<li class="dropdown-item-wrapper" data-index="0">
  <a class="dropdown-item dropdown-item-link" data-item-id="a">…</a>
</li>
<li class="dropdown-item-wrapper disabled" data-index="1">
  <a class="dropdown-item dropdown-item-link disabled" aria-disabled="true">…</a>
</li>
<li class="dropdown-item-wrapper active" data-index="2">
  <a class="dropdown-item dropdown-item-link active">…</a>
</li>
```

`.dropdown-item` now matches 3, not 6. `.dropdown-item.active` matches 1.

## One test changed, deliberately

`should mark selected item as active` did `querySelectorAll('.dropdown-item')[1].querySelector('a')`, which assumed `.dropdown-item` was the `<li>`. That assumption was the bug. It now clicks the matched element directly, because `.dropdown-item` is the anchor.

## Breaking change

`dropdown-item` has moved off the `<li>`. Anyone styling `li.dropdown-item` is affected. This corrects a divergence from Bootstrap's own markup and is worth calling out in the release notes.

## Verified

- 696 passed, 0 failed, 696 total
- Rendered DOM inspected directly, output above
