### PR TITLE
fix: sanitize URLs in Breadcrumb, Dropdown, NavigationDrawer and Sidebar

### DIFF
--- a/components/Breadcrumb/Breadcrumb.js
+++ b/components/Breadcrumb/Breadcrumb.js
@@ -8,7 +8,7 @@
 import { createComponent } from '../../utils/createComponent.js';
 import { resolveClasses, resolvePartClasses } from '../../utils/ThemeProvider.js';
 import { cn } from '../../utils/classNames.js';
-import { escapeHtml } from '../../utils/security.js';
+import { escapeHtml, sanitizeUrl } from '../../utils/security.js';
 
 /**
  * Create a breadcrumb navigation component
@@ -63,7 +63,7 @@ export function Breadcrumb({
                         <li class="${item.active ? activeClass : itemClass}"${item.active ? ' aria-current="page"' : ''}>
                             ${item.active
                                 ? `<span>${escapeHtml(item.label)}</span>`
-                                : `<a href="${escapeHtml(item.href || '#')}">${escapeHtml(item.label)}</a>`
+                                : `<a href="${escapeHtml(sanitizeUrl(item.href) || '#')}">${escapeHtml(item.label)}</a>`
                             }
                         </li>
                     `).join(`<li class="${separatorClass}" aria-hidden="true">${escapeHtml(separator)}</li>`)}

--- a/components/Dropdown/Dropdown.js
+++ b/components/Dropdown/Dropdown.js
@@ -1,5 +1,5 @@
 import { createComponent } from '../../utils/createComponent.js';
-import { escapeHtml } from '../../utils/security.js';
+import { escapeHtml, sanitizeUrl } from '../../utils/security.js';
 import { resolveClasses, resolvePartClasses } from '../../utils/ThemeProvider.js';
 import { cn } from '../../utils/classNames.js';
 
@@ -65,7 +65,7 @@ export const Dropdown = (props = {}) => {
 
         return `
             <li class="${cn(itemWrapperClass, item.disabled ? 'disabled' : '', item.active ? 'active' : '')}" role="none" data-index="${index}">
-                <a href="${escapeHtml(item.href || '#')}" class="${cn(linkClass, item.disabled ? 'disabled' : '', item.active ? 'active' : '')}" role="menuitem" tabindex="-1"${item.disabled ? ' aria-disabled="true"' : ''} data-item-id="${escapeHtml(item.id || '')}">
+                <a href="${escapeHtml(sanitizeUrl(item.href) || '#')}" class="${cn(linkClass, item.disabled ? 'disabled' : '', item.active ? 'active' : '')}" role="menuitem" tabindex="-1"${item.disabled ? ' aria-disabled="true"' : ''} data-item-id="${escapeHtml(item.id || '')}">
                     ${item.icon ? `<span class="${itemIconClass}" aria-hidden="true">${escapeHtml(item.icon)}</span>` : ''}
                     <span class="${itemTextClass}">${escapeHtml(item.label)}</span>
                     ${item.badge ? `<span class="${badgeClass}">${escapeHtml(item.badge)}</span>` : ''}

--- a/components/NavigationDrawer/NavigationDrawer.js
+++ b/components/NavigationDrawer/NavigationDrawer.js
@@ -1,7 +1,7 @@
 import { createComponent } from '../../utils/createComponent.js';
 import { resolveClasses, resolvePartClasses } from '../../utils/ThemeProvider.js';
 import { cn } from '../../utils/classNames.js';
-import { escapeHtml } from '../../utils/security.js';
+import { escapeHtml, sanitizeUrl } from '../../utils/security.js';
 
 /**
  * NavigationDrawer Component - CSS Framework Agnostic
@@ -55,7 +55,7 @@ export function NavigationDrawer({
           </div>
           <nav class="${bodyClass || 'nav flex-column'}" aria-label="Drawer">
              ${links.map((link, idx) => `
-               <a href="${escapeHtml(link.href || '#')}"
+               <a href="${escapeHtml(sanitizeUrl(link.href) || '#')}"
                   class="${cn('m3-drawer-link', link.active ? 'active' : '')}"
                   data-index="${idx}"
                   data-ref="link-${idx}"

--- a/components/Sidebar/Sidebar.js
+++ b/components/Sidebar/Sidebar.js
@@ -1,7 +1,7 @@
 import { createComponent } from '../../utils/createComponent.js';
 import { resolveClasses, resolvePartClasses } from '../../utils/ThemeProvider.js';
 import { cn } from '../../utils/classNames.js';
-import { escapeHtml } from '../../utils/security.js';
+import { escapeHtml, sanitizeUrl } from '../../utils/security.js';
 
 let sidebarUid = 0;
 
@@ -102,7 +102,7 @@ export const Sidebar = (props = {}) => {
                                 const childActive = child.active || (child.id && child.id === currentActiveItem);
                                 return `
                                     <li class="${cn(subitemClass, childActive ? 'active' : '')}">
-                                        <a href="${escapeHtml(child.href || '#')}" class="${subitemLinkClass}" data-item-id="${escapeHtml(child.id || '')}"${childActive ? ' aria-current="page"' : ''}>
+                                        <a href="${escapeHtml(sanitizeUrl(child.href) || '#')}" class="${subitemLinkClass}" data-item-id="${escapeHtml(child.id || '')}"${childActive ? ' aria-current="page"' : ''}>
                                             ${renderIcon(child.icon)}
                                             <span class="${itemTextClass}" style="${textStyle}">${escapeHtml(child.label)}</span>
                                         </a>
@@ -116,7 +116,7 @@ export const Sidebar = (props = {}) => {
 
             return `
                 <li class="${cn(itemClass, isActive ? 'active' : '')}">
-                    <a href="${escapeHtml(item.href || '#')}" class="${linkClass}" data-item-id="${escapeHtml(item.id || '')}"${isActive ? ' aria-current="page"' : ''}>
+                    <a href="${escapeHtml(sanitizeUrl(item.href) || '#')}" class="${linkClass}" data-item-id="${escapeHtml(item.id || '')}"${isActive ? ' aria-current="page"' : ''}>
                         ${renderIcon(item.icon)}
                         <span class="${itemTextClass}" style="${textStyle}">${escapeHtml(item.label)}</span>
                     </a>

--- a/tests/unit/Breadcrumb_Rendering.test.js
+++ b/tests/unit/Breadcrumb_Rendering.test.js
@@ -80,8 +80,11 @@ describe('Breadcrumb Rendering', () => {
 
         await new Promise(resolve => setTimeout(resolve, 50));
         const links = container.querySelectorAll('.breadcrumb-item a');
-        expect(links[0].href).toContain('/');
-        expect(links[1].href).toContain('/products');
+        // happy-dom does not decode HTML entities in attributes, so read the raw
+        // attribute and decode it here. A real browser resolves '&#x2F;' to '/'.
+        const href = (a) => a.getAttribute('href').replace(/&#x2F;/g, '/');
+        expect(href(links[0])).toContain('/');
+        expect(href(links[1])).toContain('/products');
 
     });
 
@@ -151,7 +154,10 @@ describe('Breadcrumb Rendering', () => {
         await new Promise(resolve => setTimeout(resolve, 50));
         const links = container.querySelectorAll('.breadcrumb-item a');
         if (links.length > 0) {
-            expect(links[0].href).toContain('javascript%3Aalert');
+            // sanitizeUrl blocks the scheme outright rather than encoding it,
+            // which is stronger than the percent-encoding this once expected.
+            expect(links[0].getAttribute('href')).toBe('#');
+            expect(links[0].getAttribute('href')).not.toContain('javascript');
         }
 
     });


### PR DESCRIPTION
Closes #39.

## The hole

Four components rendered user-supplied hrefs like this:

```js
`<a href="${escapeHtml(item.href || '#')}">`
```

`escapeHtml` escapes HTML entities. It does not touch the URL scheme, so `javascript:alert("xss")` reached the DOM as a live link and executing it was one click away.

Affected, five call sites:

- `Breadcrumb.js:66`
- `Dropdown.js:68`
- `NavigationDrawer.js:58`
- `Sidebar.js:105` and `:119`

## The fix was already written

`utils/security.js:204` has `sanitizeUrl`. It blocks `javascript:`, `data:`, `vbscript:` and `file:`, allows `http`, `https`, `mailto`, `tel` and relative URLs, and returns `null` otherwise. It is documented, and it says in its own docstring that it exists "to prevent javascript: and data: attacks".

**No component used it.** Confirmed by grep across `components/`, `framework/` and `plugins/`. It was dead security code, in the same way `css/themes/base.css` is dead theming code.

All five sites now read:

```js
escapeHtml(sanitizeUrl(item.href) || '#')
```

`sanitizeUrl` rejects the scheme, `escapeHtml` still prevents attribute breakout. Verified output:

```
href="javascript:alert(&quot;xss&quot;)"  ->  href="#"
href="/products"                          ->  href="&#x2F;products"   (a browser resolves this to /products)
```

## Two tests changed, and one of them is a spec change worth noticing

`should escape HTML in hrefs` expected `javascript%3Aalert`, that is, a percent-encoded scheme. The implementation **blocks** the URL instead, which is stronger: an encoded `javascript:` is inert only until something decodes it. The assertion now requires the href to be `#` and to contain no `javascript` at all.

`should have correct links` was failing for an unrelated reason and is not a product bug. happy-dom does not decode HTML entities in attributes, so it saw `&#x2F;products` where a browser sees `/products`. The test now reads the raw attribute and decodes it, with a comment explaining why.

## Verification

- 689 passed, 7 failed, 696 total, up from 687 passed
- rendered hrefs inspected directly, output above
- the 7 remaining failures are #40 and #41, untouched by this
