### PR TITLE
fix: Stop accordion panels taller than 24rem from being clipped

### DIFF
--- a/themes/tailwind/index.js
+++ b/themes/tailwind/index.js
@@ -523,7 +523,7 @@ export const tailwindTheme = {
         body: 'px-4 pb-4 text-sm text-slate-600'
       },
       states: {
-        show: 'max-h-96',
+        show: 'max-h-[10000px]',
         hide: 'max-h-0',
         expanded: 'rotate-180'
       },


### PR DESCRIPTION
## Summary

Stop accordion panels taller than 24rem from being clipped

## Changes

- Raise accordion expanded max-height so panels taller than 24rem are not clipped

Fixes #14


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Accordion panels can now expand to display longer content without being cut off by a height limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->