### PR TITLE
fix: green the suite, exit 0

### DIFF
--- a/components/Autocomplete/Autocomplete.js
+++ b/components/Autocomplete/Autocomplete.js
@@ -89,6 +89,9 @@ export function Autocomplete({
 
         if (isAsync) {
             isLoading = true;
+            // Render the loading state, otherwise the spinner never appears:
+            // isLoading is back to false by the time the next setState runs.
+            component.setState({ isLoading });
             try {
                 const results = await items(query);
                 isLoading = false;

--- a/tests/unit/FileUpload_Validation.test.js
+++ b/tests/unit/FileUpload_Validation.test.js
@@ -144,8 +144,16 @@ describe('FileUpload Validation', () => {
         const result1 = upload.addFiles([file1]);
         expect(result1.errors.length).toBeGreaterThan(1);
 
+        // file1 was rejected, so it does not consume the single maxFiles slot
+        // and a subsequent valid file is still accepted.
         const result2 = upload.addFiles([file2]);
-        expect(result2.errors.length).toBeGreaterThan(0);
+        expect(result2.errors).toEqual([]);
+        expect(result2.added).toHaveLength(1);
+
+        // The slot is now taken, so a third file does hit the maxFiles limit.
+        const file3 = new File(['more'], 'other.jpg', { type: 'image/jpeg' });
+        const result3 = upload.addFiles([file3]);
+        expect(result3.errors.length).toBeGreaterThan(0);
 
     });
 });

--- a/tests/unit/RouterPlugin.test.js
+++ b/tests/unit/RouterPlugin.test.js
@@ -8,6 +8,10 @@ describe('Router Plugin', () => {
   let container;
 
   beforeEach(() => {
+    // window.location persists across tests in a file, so a route pushed by an
+    // earlier test would still match here and mask defaultRoute handling.
+    window.history.replaceState({}, '', '/');
+
     // Setup DOM
     container = document.createElement('div');
     document.body.appendChild(container);
@@ -76,54 +80,44 @@ describe('Router Plugin', () => {
       manager.use(plugin);
     });
 
-    it('should match exact routes', (done) => {
+    it('should match exact routes', async () => {
       window.rnxRouter.push('/');
 
-      setTimeout(() => {
-        expect(window.rnxRouter.currentRoute()).toBe('home');
-        done();
-      }, 50);
+      await new Promise(resolve => setTimeout(resolve, 50));
+    expect(window.rnxRouter.currentRoute()).toBe('home');
     });
 
-    it('should match parameterized routes', (done) => {
+    it('should match parameterized routes', async () => {
       window.rnxRouter.push('/users/123');
 
-      setTimeout(() => {
-        expect(window.rnxRouter.currentRoute()).toBe('userDetail');
-        expect(window.rnxRouter.params()).toEqual({ id: '123' });
-        done();
-      }, 50);
+      await new Promise(resolve => setTimeout(resolve, 50));
+    expect(window.rnxRouter.currentRoute()).toBe('userDetail');
+    expect(window.rnxRouter.params()).toEqual({ id: '123' });
     });
 
-    it('should extract multiple parameters', (done) => {
+    it('should extract multiple parameters', async () => {
       window.rnxRouter.push('/users/123/posts/456');
 
-      setTimeout(() => {
-        expect(window.rnxRouter.currentRoute()).toBe('postDetail');
-        expect(window.rnxRouter.params()).toEqual({
-          id: '123',
-          postId: '456'
-        });
-        done();
-      }, 50);
+      await new Promise(resolve => setTimeout(resolve, 50));
+    expect(window.rnxRouter.currentRoute()).toBe('postDetail');
+    expect(window.rnxRouter.params()).toEqual({
+      id: '123',
+      postId: '456'
+    });
     });
 
-    it('should return 404 for unknown routes', (done) => {
+    it('should return 404 for unknown routes', async () => {
       window.rnxRouter.push('/unknown/path');
 
-      setTimeout(() => {
-        expect(window.rnxRouter.currentRoute()).toBe('404');
-        done();
-      }, 50);
+      await new Promise(resolve => setTimeout(resolve, 50));
+    expect(window.rnxRouter.currentRoute()).toBe('404');
     });
 
-    it('should handle special characters in params', (done) => {
+    it('should handle special characters in params', async () => {
       window.rnxRouter.push('/users/john-doe');
 
-      setTimeout(() => {
-        expect(window.rnxRouter.params().id).toBe('john-doe');
-        done();
-      }, 50);
+      await new Promise(resolve => setTimeout(resolve, 50));
+    expect(window.rnxRouter.params().id).toBe('john-doe');
     });
   });
 
@@ -133,67 +127,55 @@ describe('Router Plugin', () => {
         routes: {
           '/': 'home',
           '/about': 'about',
-          '/contact': 'contact'
+          '/contact': 'contact',
+          '/users/:id': 'user'
         }
       });
 
       manager.use(plugin);
     });
 
-    it('should navigate with push()', (done) => {
+    it('should navigate with push()', async () => {
       window.rnxRouter.push('/about');
 
-      setTimeout(() => {
-        expect(window.rnxRouter.currentRoute()).toBe('about');
-        done();
-      }, 50);
+      await new Promise(resolve => setTimeout(resolve, 50));
+    expect(window.rnxRouter.currentRoute()).toBe('about');
     });
 
-    it('should navigate with replace()', (done) => {
+    it('should navigate with replace()', async () => {
       window.rnxRouter.replace('/contact');
 
-      setTimeout(() => {
-        expect(window.rnxRouter.currentRoute()).toBe('contact');
-        done();
-      }, 50);
+      await new Promise(resolve => setTimeout(resolve, 50));
+    expect(window.rnxRouter.currentRoute()).toBe('contact');
     });
 
-    it('should support back() navigation', (done) => {
+    it('should support back() navigation', async () => {
       window.rnxRouter.push('/about');
-      setTimeout(() => {
-        window.rnxRouter.back();
-        setTimeout(() => {
-          // Back navigates in history
-          done();
-        }, 50);
-      }, 50);
+      await new Promise(resolve => setTimeout(resolve, 50));
+    window.rnxRouter.back();
+    await new Promise(resolve => setTimeout(resolve, 50));
+  // Back navigates in history
     });
 
-    it('should return current route', (done) => {
+    it('should return current route', async () => {
       window.rnxRouter.push('/about');
 
-      setTimeout(() => {
-        expect(window.rnxRouter.currentRoute()).toBe('about');
-        done();
-      }, 50);
+      await new Promise(resolve => setTimeout(resolve, 50));
+    expect(window.rnxRouter.currentRoute()).toBe('about');
     });
 
-    it('should return current path', (done) => {
+    it('should return current path', async () => {
       window.rnxRouter.push('/about');
 
-      setTimeout(() => {
-        expect(window.rnxRouter.path()).toBe('/about');
-        done();
-      }, 50);
+      await new Promise(resolve => setTimeout(resolve, 50));
+    expect(window.rnxRouter.path()).toBe('/about');
     });
 
-    it('should return current params', (done) => {
+    it('should return current params', async () => {
       window.rnxRouter.push('/users/123');
 
-      setTimeout(() => {
-        expect(window.rnxRouter.params()).toEqual({ id: '123' });
-        done();
-      }, 50);
+      await new Promise(resolve => setTimeout(resolve, 50));
+    expect(window.rnxRouter.params()).toEqual({ id: '123' });
     });
   });
 
@@ -219,42 +201,38 @@ describe('Router Plugin', () => {
       manager.use(plugin);
     });
 
-    it('should show active route element', (done) => {
+    it('should show active route element', async () => {
       window.rnxRouter.push('/');
 
-      setTimeout(() => {
-        const home = container.querySelector('[data-route="home"]');
-        const about = container.querySelector('[data-route="about"]');
+      await new Promise(resolve => setTimeout(resolve, 50));
+    const home = container.querySelector('[data-route="home"]');
+    const about = container.querySelector('[data-route="about"]');
 
-        expect(home.style.display).not.toBe('none');
-        expect(about.style.display).toBe('none');
-        done();
-      }, 50);
+    expect(home.style.display).not.toBe('none');
+    expect(about.style.display).toBe('none');
     });
 
-    it('should toggle route elements on navigation', (done) => {
+    it('should toggle route elements on navigation', async () => {
       window.rnxRouter.push('/');
 
-      setTimeout(() => {
-        const home = container.querySelector('[data-route="home"]');
-        expect(home.style.display).not.toBe('none');
+      await new Promise(resolve => setTimeout(resolve, 50));
+    const home = container.querySelector('[data-route="home"]');
+    expect(home.style.display).not.toBe('none');
 
-        window.rnxRouter.push('/about');
+    window.rnxRouter.push('/about');
 
-        setTimeout(() => {
-          const home = container.querySelector('[data-route="home"]');
-          const about = container.querySelector('[data-route="about"]');
+    await new Promise(resolve => setTimeout(resolve, 50));
+    // re-query: the router re-renders, so the earlier reference is stale
+    const homeAfter = container.querySelector('[data-route="home"]');
+    const about = container.querySelector('[data-route="about"]');
 
-          expect(home.style.display).toBe('none');
-          expect(about.style.display).not.toBe('none');
-          done();
-        }, 50);
-      }, 50);
+    expect(homeAfter.style.display).toBe('none');
+    expect(about.style.display).not.toBe('none');
     });
   });
 
   describe('Route Callbacks', () => {
-    it('should call onRouteChange callback', (done) => {
+    it('should call onRouteChange callback', async () => {
       const onRouteChange = vi.fn();
 
       const plugin = routerPlugin({
@@ -269,17 +247,16 @@ describe('Router Plugin', () => {
 
       window.rnxRouter.push('/about');
 
-      setTimeout(() => {
-        expect(onRouteChange).toHaveBeenCalled();
-        const arg = onRouteChange.mock.calls[0][0];
-        expect(arg.name).toBe('about');
-        done();
-      }, 50);
+      await new Promise(resolve => setTimeout(resolve, 50));
+    expect(onRouteChange).toHaveBeenCalled();
+    // assert the most recent call: the router also fires once on init
+    const arg = onRouteChange.mock.calls.at(-1)[0];
+    expect(arg.name).toBe('about');
     });
   });
 
   describe('Default Route', () => {
-    it('should use default route on init', (done) => {
+    it('should use default route on init', async () => {
       const plugin = routerPlugin({
         routes: {
           '/home': 'home',
@@ -290,15 +267,13 @@ describe('Router Plugin', () => {
 
       manager.use(plugin);
 
-      setTimeout(() => {
-        expect(window.rnxRouter.currentRoute()).toBe('home');
-        done();
-      }, 50);
+      await new Promise(resolve => setTimeout(resolve, 50));
+    expect(window.rnxRouter.currentRoute()).toBe('home');
     });
   });
 
   describe('State Management', () => {
-    it('should maintain reactive state', (done) => {
+    it('should maintain reactive state', async () => {
       const plugin = routerPlugin({
         routes: {
           '/': 'home',
@@ -310,11 +285,9 @@ describe('Router Plugin', () => {
 
       window.rnxRouter.push('/users/123');
 
-      setTimeout(() => {
-        expect(window.rnxRouter.state.currentRoute).toBe('userDetail');
-        expect(window.rnxRouter.state.params.id).toBe('123');
-        done();
-      }, 50);
+      await new Promise(resolve => setTimeout(resolve, 50));
+    expect(window.rnxRouter.state.currentRoute).toBe('userDetail');
+    expect(window.rnxRouter.state.params.id).toBe('123');
     });
   });
 });

--- a/tests/unit/ToastPlugin.test.js
+++ b/tests/unit/ToastPlugin.test.js
@@ -163,7 +163,6 @@ describe('Toast Plugin', () => {
     await new Promise(resolve => setTimeout(resolve, 350));
   const toast = document.querySelector('.rnx-toast');
   expect(toast).toBeNull();
-  done(); // Wait for animation
     });
 
     it('should auto-dismiss after duration', async () => {
@@ -182,7 +181,7 @@ describe('Toast Plugin', () => {
     window.rnx.toast.clear();
 
     await new Promise(resolve => setTimeout(resolve, 350));
-  const toasts = document.querySelectorAll('.rnx-toast');
+  const toasts = document.querySelectorAll('.rnx-toast:not(.rnx-toast-hide)');
   expect(toasts.length).toBe(0);
     });
 
@@ -196,7 +195,7 @@ describe('Toast Plugin', () => {
       window.rnx.toast.show('Message 3');
 
       await new Promise(resolve => setTimeout(resolve, 50));
-    const toasts = document.querySelectorAll('.rnx-toast');
+    const toasts = document.querySelectorAll('.rnx-toast:not(.rnx-toast-hide)');
     expect(toasts.length).toBeLessThanOrEqual(2);
     });
   });
@@ -273,7 +272,7 @@ describe('Toast Plugin', () => {
       window.rnx.toast.warning('Message 3');
 
       await new Promise(resolve => setTimeout(resolve, 50));
-    const toasts = document.querySelectorAll('.rnx-toast');
+    const toasts = document.querySelectorAll('.rnx-toast:not(.rnx-toast-hide)');
     expect(toasts.length).toBe(3);
     });
 
@@ -289,7 +288,7 @@ describe('Toast Plugin', () => {
     window.rnx.toast.show('Message 3');
 
     await new Promise(resolve => setTimeout(resolve, 50));
-  const toasts = document.querySelectorAll('.rnx-toast');
+  const toasts = document.querySelectorAll('.rnx-toast:not(.rnx-toast-hide)');
   expect(toasts.length).toBeLessThanOrEqual(2);
     });
   });

--- a/themes/bootstrap/index.js
+++ b/themes/bootstrap/index.js
@@ -560,8 +560,9 @@ export const bootstrapTheme = {
     },
 
     fileupload: {
-      base: 'file-upload',
+      base: 'file-upload-wrapper',
       parts: {
+        zone: 'file-upload',
         input: 'form-control',
         label: 'form-label',
         preview: 'file-upload-preview'

--- a/themes/tailwind/index.js
+++ b/themes/tailwind/index.js
@@ -623,8 +623,9 @@ export const tailwindTheme = {
     },
 
     fileupload: {
-      base: 'border-2 border-dashed border-slate-300 rounded-lg p-8 text-center bg-white hover:border-indigo-400 hover:bg-indigo-50/30 transition-colors duration-150 motion-reduce:transition-none',
+      base: '',
       parts: {
+        zone: 'border-2 border-dashed border-slate-300 rounded-lg p-8 text-center bg-white hover:border-indigo-400 hover:bg-indigo-50/30 transition-colors duration-150 motion-reduce:transition-none',
         input: 'hidden',
         label: 'block text-sm font-medium text-slate-700 mb-1.5',
         preview: 'mt-4 grid grid-cols-2 sm:grid-cols-4 gap-3',


### PR DESCRIPTION
Closes #37, #40, #41. `npm test` now exits 0, deterministically over three consecutive runs, with no unhandled errors and no `done()` left anywhere in `tests/`.

```
Test Files  39 passed (39)
     Tests  696 passed (696)
      exit  0
```

Total is unchanged at 696, so nothing was deleted or skipped to get here.

## Two real component bugs

**Autocomplete never showed its loading state.** `Autocomplete.js:91` set `isLoading = true` and never called `setState`, so the component did not re-render. By the time the next `setState` ran, `isLoading` was already back to `false`. The spinner markup at `:252` was unreachable in every async configuration. Probed at 5ms, 25ms, 60ms and 150ms after an async search: `.autocomplete-loading` was absent at all four.

**FileUpload's drop-zone styling was on the wrong element.** Both themes put it on `base`, which the component applies to the wrapper, while the zone reads `parts.zone`, which neither theme defined. Consequences:

- Under `css/bootstrap-m3-theme.css`, wrapper and zone both matched `.file-upload:794`, so the dashed box rendered nested twice.
- Under Tailwind, `drag-over` landed on an element with no styling, so drag feedback was invisible.
- `container.querySelector('.file-upload')` returned the wrapper, not the zone. The tests dispatched drag events at the wrapper, and since events bubble upward they never reached the listener on the child.

That last part is the same defect as #25: one class name arriving on two elements from two independent sources. Fixed by adding a `zone` part to both themes and moving the box styling onto it. No component change was needed; `FileUpload.js:164` already read a `zone` part that had never been added.

## Test bugs

- **Toast (#40)**: three tests counted `.rnx-toast` nodes 50ms after a removal that defers DOM removal by 300ms for the exit animation. They now count `.rnx-toast:not(.rnx-toast-hide)`, which tests the intent rather than an animation duration.
- **Toast**: one `done(); // Wait for animation` survived #38 because the conversion only matched `done();` at end of line.
- **FileUpload validation**: asserted that a *rejected* file consumes a `maxFiles` slot. It does not, correctly, since `addFiles` only counts accepted files. Rewritten to assert that behaviour explicitly, then to check the limit does fire once a valid file occupies the slot.
- **RouterPlugin params**: pushed `/users/123` in a block whose `beforeEach` registered only `/`, `/about` and `/contact`. No parameterised route existed, so `params()` returning `{}` was right. The route is now registered.
- **RouterPlugin default route**: `window.location` persists across tests in a file, so a URL pushed earlier still matched and masked `defaultRoute`. Reset in `beforeEach`.
- **RouterPlugin callback**: asserted on `mock.calls[0]`. With location properly reset, the router fires once on init before the push, so the assertion now reads the most recent call.

## RouterPlugin was the worst of it

Those 19 tests were passing without their assertions ever being checked, because each body ran inside a `setTimeout` that resolved after the test had ended. Converting them surfaced the two failures above. Its nested timeouts also declared `const home` twice in what were separate closures, which collide once flattened, so that one needed hand-finishing rather than the mechanical conversion.

## What this unblocks

CI can now be required. Nothing could be gated on a suite that exited 1 for reasons unrelated to the change under review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Autocomplete now displays its loading indicator immediately during asynchronous searches.
  - File upload validation correctly preserves the available slot when a file is rejected.
  - File upload styling now applies consistently across Bootstrap and Tailwind themes.

- **Tests**
  - Improved coverage for routing, notifications, and file upload validation scenarios.
  - Updated asynchronous test handling for more reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->