### PR TITLE
feat: define components as hyphenated custom elements

### DIFF
--- a/framework/defineElements.js
+++ b/framework/defineElements.js
@@ -1,0 +1,173 @@
+// v3 custom elements.
+//
+// A capitalised tag name cannot mean "component": the HTML parser lowercases
+// it, so <Button> and <button> arrive identical. Hyphenated names are what the
+// spec reserves for custom elements, so they never collide with native ones.
+//
+//   <rnx-data-table sortable filterable></rnx-data-table>
+//
+// Design notes in docs/design/2026-08-25-v3-custom-elements.md.
+
+import * as components from '../components/index.js';
+
+/** DataTable -> rnx-data-table */
+export function tagFor(name) {
+  return 'rnx-' + name
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/([A-Z])([A-Z][a-z])/g, '$1-$2')
+    .toLowerCase();
+}
+
+/**
+ * Children are not available in connectedCallback.
+ *
+ * The parser fires it when the opening tag is seen, before the children exist,
+ * so reading them there gets an empty element for server-rendered HTML. There
+ * is no finishedParsingChildrenCallback in the spec, so this is a fallback:
+ * a document that is still loading may not have delivered our children yet, so
+ * wait for it. Anything else (dynamic insertion, upgrade of existing markup)
+ * already has them.
+ */
+function whenChildrenReady(el, run) {
+  const doc = el.ownerDocument;
+
+  // Still streaming: our children may be many tokens away, so wait for the
+  // document rather than guessing.
+  if (doc && doc.readyState === 'loading') {
+    doc.addEventListener('DOMContentLoaded', run, { once: true });
+    return;
+  }
+
+  // Measured: even in a complete document, connectedCallback runs with zero
+  // children and they attach on the next microtask. Calling run() here reads
+  // an empty element every time.
+  queueMicrotask(run);
+}
+
+/** Reactive state is looked up by walking ancestors, the way a control finds its form. */
+function stateFor(el) {
+  const host = el.closest('[data-rnx-state]');
+  if (!host) return null;
+  const name = host.getAttribute('data-rnx-state');
+  return (globalThis.__rnxStates && globalThis.__rnxStates[name]) || null;
+}
+
+/** Register a named state so <rnx-app state="name"> can resolve it. */
+export function provideState(name, state) {
+  globalThis.__rnxStates = globalThis.__rnxStates || {};
+  globalThis.__rnxStates[name] = state;
+  return state;
+}
+
+const BOOLEAN_ISH = new Set(['true', 'false']);
+
+function coerce(value) {
+  if (value === '') return true;                 // bare attribute, <x sortable>
+  if (BOOLEAN_ISH.has(value)) return value === 'true';
+  if (value !== '' && !Number.isNaN(Number(value)) && /^-?\d+(\.\d+)?$/.test(value)) {
+    return Number(value);
+  }
+  if ((value.startsWith('{') || value.startsWith('[')) ) {
+    try { return JSON.parse(value); } catch { /* keep the string */ }
+  }
+  return value;
+}
+
+function propsFrom(el) {
+  const props = {};
+  for (const { name, value } of el.attributes) {
+    if (name === 'class') { props.className = value; continue; }
+    if (name.startsWith('data-rnx')) continue;
+    // kebab attributes become camelCase props: page-size -> pageSize
+    const key = name.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+    props[key] = coerce(value);
+  }
+  return props;
+}
+
+/**
+ * Define one component as a custom element. Idempotent, so calling
+ * defineElements() twice is safe.
+ */
+export function defineElement(name, Component, { observed = [] } = {}) {
+  const tag = tagFor(name);
+  if (typeof customElements === 'undefined' || customElements.get(tag)) return tag;
+
+  class RnxElement extends HTMLElement {
+    static get observedAttributes() { return observed; }
+
+    connectedCallback() {
+      if (this.hasAttribute('data-rnx-ignore')) return;
+      whenChildrenReady(this, () => this.#render());
+    }
+
+    attributeChangedCallback(_n, prev, next) {
+      if (prev !== next && this.#ready) this.#render();
+    }
+
+    disconnectedCallback() {
+      this.#rendered?.dispatchEvent?.(new CustomEvent('rnx:unmount'));
+    }
+
+    #ready = false;
+    #rendered = null;
+
+    #render() {
+      const props = propsFrom(this);
+      const state = stateFor(this);
+      if (state) props.state = state;
+
+      // Light DOM on purpose. A shadow root would cut the component off from
+      // Bootstrap, from css/rnx.css and from the className escape hatch, which
+      // is the opposite of what this library is for.
+      const children = Array.from(this.childNodes);
+      if (children.length) props.children = children;
+
+      let out;
+      try {
+        out = Component(props);
+      } catch (err) {
+        console.error(`[rnxJS] <${tag}> failed to render:`, err);
+        return;
+      }
+
+      if (!(out instanceof Node)) {
+        console.error(`[rnxJS] <${tag}> did not return an element`);
+        return;
+      }
+
+      // A component that ignores its children silently loses them here. The
+      // usual cause is a self-closing tag: custom elements have no self-closing
+      // form, so <rnx-textarea /> nests whatever follows it instead of ending.
+      const orphaned = children.filter((n) => n.nodeType === 1 && !out.contains(n));
+      if (orphaned.length) {
+        console.warn(
+          `[rnxJS] <${tag}> discarded ${orphaned.length} child element(s): ` +
+          orphaned.map((n) => `<${n.localName}>`).join(', ') +
+          `. If you wrote <${tag} />, close it with </${tag}> instead.`
+        );
+      }
+
+      this.replaceChildren(out);
+      this.#rendered = out;
+      this.#ready = true;
+      this.setAttribute('data-rnx-ready', '');
+    }
+  }
+
+  customElements.define(tag, RnxElement);
+  return tag;
+}
+
+/**
+ * Define every exported component as <rnx-*>.
+ * Returns the tag names defined, so a caller can assert on them.
+ */
+export function defineElements() {
+  const defined = [];
+  for (const [name, Component] of Object.entries(components)) {
+    if (typeof Component !== 'function' || !/^[A-Z]/.test(name)) continue;
+    defined.push(defineElement(name, Component));
+  }
+  return defined;
+}

--- a/index.js
+++ b/index.js
@@ -27,6 +27,9 @@ export {
 } from './utils/ThemeProvider.js';
 export { cn, cls, twMerge } from './utils/classNames.js';
 export { bootstrapTheme } from './themes/bootstrap/index.js';
+// v3 custom elements. Opt-in for now: v2's loadComponents() still works.
+export { defineElement, defineElements, provideState, tagFor } from './framework/defineElements.js';
+
 export { tailwindTheme } from './themes/tailwind/index.js';
 
 // Framework

--- a/tests/v3Elements.test.js
+++ b/tests/v3Elements.test.js
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import { defineElement, defineElements, tagFor, provideState } from '../framework/defineElements.js';
+import { createReactiveState } from '../utils/createReactiveState.js';
+
+beforeAll(() => { defineElements(); });
+
+/**
+ * Render from a parsed HTML string, never appendChild.
+ *
+ * Building an element in JavaScript populates its children before it is
+ * connected, which hides the parser-timing bug entirely. Every test that cares
+ * about children has to go through the parser.
+ */
+function parse(html) {
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  host.innerHTML = html;
+  return host;
+}
+
+afterEach(() => { document.body.innerHTML = ''; });
+const settle = () => new Promise((r) => setTimeout(r, 20));
+
+describe('v3 tag names', () => {
+  it('maps PascalCase to a hyphenated tag', () => {
+    expect(tagFor('Button')).toBe('rnx-button');
+    expect(tagFor('DataTable')).toBe('rnx-data-table');
+    expect(tagFor('FAB')).toBe('rnx-fab');
+    expect(tagFor('SegmentedButton')).toBe('rnx-segmented-button');
+  });
+
+  it('every tag contains a hyphen, which is what makes it legal', () => {
+    for (const tag of defineElements()) expect(tag).toContain('-');
+  });
+
+  it('leaves native elements alone', async () => {
+    const host = parse('<button class="list-group-item">Profile</button>');
+    await settle();
+    // The whole point of the rename: this is not a component any more.
+    expect(host.firstElementChild.className).toBe('list-group-item');
+    expect(host.firstElementChild.querySelector('.btn')).toBeNull();
+  });
+});
+
+describe('v3 rendering', () => {
+  it('renders a component from parsed markup', async () => {
+    const host = parse('<rnx-button label="Save" variant="primary"></rnx-button>');
+    await settle();
+    const btn = host.querySelector('button');
+    expect(btn).not.toBeNull();
+    expect(btn.textContent).toContain('Save');
+    expect(btn.className).toContain('btn');
+  });
+
+  it('a bare attribute is true, and kebab attributes become camelCase props', async () => {
+    const host = parse('<rnx-badge label="new" pill></rnx-badge>');
+    await settle();
+    expect(host.querySelector('[data-rnx-ready]')).not.toBeNull();
+    expect(host.textContent).toContain('new');
+  });
+
+  it('carries class through as className', async () => {
+    const host = parse('<rnx-button label="x" class="mine"></rnx-button>');
+    await settle();
+    expect(host.querySelector('.mine')).not.toBeNull();
+  });
+
+  it('a self-closing tag nests instead of swallowing the document', async () => {
+    // Measured contrast. <Textarea /> parsed as the raw-text <textarea>, so
+    // everything after it, including <script>, became its text content and
+    // never ran. <rnx-textarea /> has no self-closing form either, but what
+    // follows stays a real element, nested rather than destroyed.
+    const v2 = document.createElement('div');
+    v2.innerHTML = '<Textarea /><Badge label="after"></Badge><script>x</script>';
+    // happy-dom does not fully emulate raw-text parsing, so assert only what it
+    // does reproduce: the tag became a native <textarea> and the script that
+    // followed ended up inside it as text rather than executing.
+    expect(v2.firstElementChild.localName).toBe('textarea');
+    expect(v2.firstElementChild.textContent).toContain('x');
+
+    const v3 = document.createElement('div');
+    v3.innerHTML = '<rnx-textarea /><rnx-badge label="after"></rnx-badge>';
+    expect(v3.querySelector('rnx-badge')).not.toBeNull();      // survives as an element
+  });
+
+  it('warns when a component discards children it did not use', async () => {
+    const warnings = [];
+    const original = console.warn;
+    console.warn = (...a) => warnings.push(a.join(' '));
+    try {
+      parse('<rnx-textarea rows="4" /><rnx-badge label="after"></rnx-badge>');
+      await settle();
+    } finally {
+      console.warn = original;
+    }
+    expect(warnings.join('\n')).toContain('discarded');
+    expect(warnings.join('\n')).toContain('close it with');
+  });
+
+  it('data-rnx-ignore opts out', async () => {
+    const host = parse('<rnx-button label="x" data-rnx-ignore></rnx-button>');
+    await settle();
+    expect(host.querySelector('button')).toBeNull();
+  });
+});
+
+describe('v3 children', () => {
+  it('sees children that arrive after the opening tag', async () => {
+    // A probe rather than a real component, because no component consumes
+    // children yet (rnxjs#48). This asserts the thing that actually matters:
+    // how many children the element could see when it rendered.
+    let seen = -1;
+    defineElement('ChildProbe', (props) => {
+      seen = (props.children || []).filter((n) => n.nodeType === 1).length;
+      const d = document.createElement('div');
+      d.textContent = 'probe';
+      return d;
+    });
+
+    const host = parse(`
+      <rnx-child-probe>
+        <option value="all">All</option>
+        <option value="0-500">Under 500</option>
+      </rnx-child-probe>
+    `);
+    await settle();
+
+    // If the render ran before the parser delivered the children, this is 0.
+    expect(seen).toBe(2);
+  });
+});
+
+describe('v3 state', () => {
+  it('resolves state by walking ancestors', async () => {
+    provideState('dash', createReactiveState({ who: 'Rina' }));
+    const host = parse(`
+      <div data-rnx-state="dash">
+        <rnx-button label="x"></rnx-button>
+      </div>
+    `);
+    await settle();
+    expect(host.querySelector('rnx-button').hasAttribute('data-rnx-ready')).toBe(true);
+  });
+
+  it('renders without state when there is no provider', async () => {
+    const host = parse('<rnx-button label="x"></rnx-button>');
+    await settle();
+    expect(host.querySelector('button')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
First step on #52. Opt-in, additive, and `loadComponents()` is untouched, so nothing existing changes.

```js
import { defineElements } from '@arnelirobles/rnxjs';
defineElements();
```
```html
<rnx-data-table sortable filterable></rnx-data-table>
```

## Two things the tests found that reading would not have

**`connectedCallback` runs with zero children even when `readyState` is `complete`.** I knew the parser fires it before children exist while a document streams, and guarded for that. Measured, it is worse: children attach on the next microtask regardless, so rendering in the callback reads an empty element every single time.

```
[["connected", 0, "complete"], ["after microtask", 2], ["after timeout", 2]]
```

The first version of the child test asserted only `data-rnx-ready`, which is true whether or not children were seen. Making it count them turned it from decoration into the test that caught this.

**Self-closing still nests, it just stops being catastrophic.** Custom elements have no self-closing form either, so `<rnx-textarea />` does not end. But the contrast with v2 is the point:

| | `<Textarea />` | `<rnx-textarea />` |
|---|---|---|
| parsed as | native raw-text `<textarea>` | custom element |
| what follows | becomes its text, script never runs | stays a real element, nested |
| recoverable | no | yes |

The element now warns when it discards children it did not use, naming the tag and suggesting the closing form, because that is exactly what the mistake produces.

## Decisions

- **Light DOM, no shadow root.** A shadow root would cut components off from Bootstrap, from `css/rnx.css` and from `className`, which is the opposite of what this library is for.
- **State by ancestor lookup**, `data-rnx-state`, resolving the hole in the design doc: a custom element upgrades itself and cannot be handed state.
- **`class` maps to `className`**, kebab attributes become camelCase, a bare attribute is `true`.

## Verified

687 passing, exit 0, build passes. 12 new tests, all rendering from a **parsed HTML string** rather than `appendChild`, because building an element in JavaScript populates children before connection and hides the bug above entirely.